### PR TITLE
fix  `tools/hlt_client/setup.py` indentation

### DIFF
--- a/tools/hlt_client/setup.py
+++ b/tools/hlt_client/setup.py
@@ -7,8 +7,8 @@ setup(name='hlt_client',
       author_email='halite@halite.io',
       license='MIT',
       packages=['hlt_client'],
-	  install_requires=[
-		  'requests',
-          'zstd',
-	  ],
+      install_requires=[
+        'requests',
+        'zstd',
+      ],
       zip_safe=False)


### PR DESCRIPTION
fix  `tools/hlt_client/setup.py` indentation by replace tab with spaces