### PR TITLE
Fix occasional crash in Halite environment (fixes #23)

### DIFF
--- a/environment/networking/Networking.cpp
+++ b/environment/networking/Networking.cpp
@@ -336,9 +336,14 @@ std::string Networking::get_string(hlt::PlayerId player_tag,
 std::string Networking::read_trailing_input(hlt::PlayerId player_tag, long max_lines) {
     std::string error_string = "";
     for(int line = 0; line < max_lines; line++) {
-        try{
+        try {
             error_string += get_string(player_tag, 0);
-        } catch(BotInputError exc) {
+        } catch (const BotInputError& exc) {
+            break;
+        } catch (const std::string& s) {
+            error_string += s;
+            break;
+        } catch (...) {
             break;
         }
     }


### PR DESCRIPTION
The game environment was terminating sporadically due to an uncaught std::string thrown in handle_frame_networking. The culprit was read_trailing_input, which caught BotInputError, but failed to account for the fact that get_string can also throw std::string. read_trailing_input gives get_string a timeout of 0 milliseconds, so if it took any non-negligible amount of time to read the string, it would throw an error instead of returning normally, and since read_trailing_input was called inside a catch() {} block, the catchall handler would not catch the exception.