### PR TITLE
Bring repo schema in line with reality.

### DIFF
--- a/apiserver/alembic.ini
+++ b/apiserver/alembic.ini
@@ -1,0 +1,74 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+file_template = %%(year)d%%(month).2d%%(day).2d%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+timezone = UTC
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = mysql+pymysql://user:pass@localhost/dbname
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/apiserver/alembic/versions/201710031816_7f0054256cf5_initial_database_schema.py
+++ b/apiserver/alembic/versions/201710031816_7f0054256cf5_initial_database_schema.py
@@ -455,7 +455,7 @@ def upgrade():
                   autoincrement=False, nullable=False),
         sa.Column('version_number', mysql.MEDIUMINT(display_width=8,
                   unsigned=True), autoincrement=False, nullable=False),
-        sa.Column('log_name', mysql.VARCHAR(length=64), nullable=True),
+        sa.Column('log_name', mysql.VARCHAR(length=256), nullable=True),
         sa.Column('rank', mysql.SMALLINT(display_width=5, unsigned=True),
                   autoincrement=False, nullable=False),
         sa.Column('player_index', mysql.SMALLINT(display_width=5,

--- a/apiserver/alembic/versions/201710171143_33de9025cc63_change_game_id_type.py
+++ b/apiserver/alembic/versions/201710171143_33de9025cc63_change_game_id_type.py
@@ -1,7 +1,7 @@
 """Change game id type.
 
 Revision ID: 33de9025cc63
-Revises: 7f0054256cf5
+Revises: e7920cc5568a
 Create Date: 2017-10-17 11:43:45.380672+00:00
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = '33de9025cc63'
-down_revision = '7f0054256cf5'
+down_revision = 'e7920cc5568a'
 branch_labels = None
 depends_on = None
 

--- a/apiserver/alembic/versions/201710180051_e7920cc5568a_add_is_gpu_enabled_field_to_user_table.py
+++ b/apiserver/alembic/versions/201710180051_e7920cc5568a_add_is_gpu_enabled_field_to_user_table.py
@@ -1,7 +1,7 @@
 """Add is_gpu_enabled field to user table.
 
 Revision ID: e7920cc5568a
-Revises: 33de9025cc63
+Revises: 7f0054256cf5
 Create Date: 2017-10-18 00:51:17.501319+00:00
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = 'e7920cc5568a'
-down_revision = '33de9025cc63'
+down_revision = '7f0054256cf5'
 branch_labels = None
 depends_on = None
 

--- a/apiserver/sql/schema.sql
+++ b/apiserver/sql/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE badge (
     id MEDIUMINT(8) UNSIGNED NOT NULL, 
     name VARCHAR(256) NOT NULL, 
     PRIMARY KEY (id)
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE UNIQUE INDEX name ON badge (name);
 
@@ -23,7 +23,7 @@ CREATE TABLE game (
     time_played DATETIME DEFAULT CURRENT_TIMESTAMP, 
     replay_bucket SMALLINT(5) NOT NULL DEFAULT '0', 
     PRIMARY KEY (id)
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX game_time_played ON game (time_played);
 
@@ -50,7 +50,7 @@ CREATE TABLE halite_1_user (
     `isEmailGood` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0', 
     level ENUM('High School','Undergraduate','Graduate','Professional') NOT NULL DEFAULT 'Professional', 
     PRIMARY KEY (`userID`)
-)DEFAULT CHARSET=latin1 AUTO_INCREMENT=5350 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=latin1 AUTO_INCREMENT=5350;
 
 CREATE TABLE organization (
     id INTEGER(11) NOT NULL AUTO_INCREMENT, 
@@ -58,7 +58,7 @@ CREATE TABLE organization (
     kind ENUM('High School','University','Professional School','Company','Other') NOT NULL DEFAULT 'Other', 
     verification_code VARCHAR(32), 
     PRIMARY KEY (id)
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE UNIQUE INDEX verification_code ON organization (verification_code);
 
@@ -70,14 +70,14 @@ CREATE TABLE game_stat (
     ships_destroyed INTEGER(10) UNSIGNED NOT NULL, 
     PRIMARY KEY (game_id), 
     CONSTRAINT game_stat_ibfk_1 FOREIGN KEY(game_id) REFERENCES game (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE game_view_stat (
     game_id MEDIUMINT(8) UNSIGNED NOT NULL, 
     views_total INTEGER(10) UNSIGNED NOT NULL, 
     PRIMARY KEY (game_id), 
     CONSTRAINT game_view_stat_ibfk_1 FOREIGN KEY(game_id) REFERENCES game (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE hackathon (
     id INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT, 
@@ -92,7 +92,7 @@ CREATE TABLE hackathon (
     is_open TINYINT(4) NOT NULL DEFAULT '0', 
     PRIMARY KEY (id), 
     CONSTRAINT hackathon_ibfk_1 FOREIGN KEY(organization_id) REFERENCES organization (id)
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX organization_id ON hackathon (organization_id);
 
@@ -103,7 +103,7 @@ CREATE TABLE organization_email_domain (
     domain VARCHAR(64) NOT NULL, 
     PRIMARY KEY (organization_id, domain), 
     CONSTRAINT organization_email_domain_ibfk_1 FOREIGN KEY(organization_id) REFERENCES organization (id)
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE user (
     id MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT, 
@@ -124,10 +124,9 @@ CREATE TABLE user (
     update_time DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP, 
     api_key_hash VARCHAR(255), 
     is_admin TINYINT(1) DEFAULT '0', 
-    `is_gpu_enabled` tinyint(1) NOT NULL DEFAULT '0',
     PRIMARY KEY (id), 
     CONSTRAINT user_ibfk_1 FOREIGN KEY(organization_id) REFERENCES organization (id)
-)DEFAULT CHARSET=utf8 AUTO_INCREMENT=1000 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1000;
 
 CREATE INDEX organization_id ON user (organization_id);
 
@@ -147,7 +146,7 @@ CREATE TABLE bot (
     timeout_sent TINYINT(1) DEFAULT '0', 
     PRIMARY KEY (user_id, id), 
     CONSTRAINT bot_ibfk_2 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE hackathon_participant (
     hackathon_id INTEGER(10) UNSIGNED NOT NULL, 
@@ -155,7 +154,7 @@ CREATE TABLE hackathon_participant (
     PRIMARY KEY (hackathon_id, user_id), 
     CONSTRAINT hackathon_participant_ibfk_4 FOREIGN KEY(hackathon_id) REFERENCES hackathon (id) ON DELETE CASCADE, 
     CONSTRAINT hackathon_participant_ibfk_3 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX user_id ON hackathon_participant (user_id);
 
@@ -168,7 +167,7 @@ CREATE TABLE user_badge (
     PRIMARY KEY (user_id, badge_id), 
     CONSTRAINT user_badge_ibfk_2 FOREIGN KEY(badge_id) REFERENCES badge (id) ON DELETE CASCADE, 
     CONSTRAINT user_badge_ibfk_1 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX fk_badge_id_idx ON user_badge (badge_id);
 
@@ -181,7 +180,7 @@ CREATE TABLE user_notification (
     creation_time DATETIME DEFAULT CURRENT_TIMESTAMP, 
     PRIMARY KEY (id), 
     CONSTRAINT user_notification_ibfk_2 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX user_id ON user_notification (user_id);
 
@@ -192,7 +191,7 @@ CREATE TABLE user_tier_history (
     total_time_in_tier INTEGER(10) UNSIGNED DEFAULT '0', 
     PRIMARY KEY (user_id, tier), 
     CONSTRAINT user_tier_history_ibfk_2 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE bot_history (
     user_id MEDIUMINT(8) UNSIGNED NOT NULL, 
@@ -207,7 +206,7 @@ CREATE TABLE bot_history (
     PRIMARY KEY (user_id, bot_id, version_number), 
     CONSTRAINT bot_history_ibfk_4 FOREIGN KEY(user_id, bot_id) REFERENCES bot (user_id, id) ON DELETE CASCADE, 
     CONSTRAINT bot_history_ibfk_3 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE game_bot_stat (
     game_id MEDIUMINT(8) UNSIGNED NOT NULL, 
@@ -224,7 +223,7 @@ CREATE TABLE game_bot_stat (
     CONSTRAINT game_bot_stat_ibfk_1 FOREIGN KEY(game_id) REFERENCES game (id) ON DELETE CASCADE, 
     CONSTRAINT fkcompid FOREIGN KEY(user_id, bot_id) REFERENCES bot (user_id, id) ON DELETE NO ACTION ON UPDATE NO ACTION, 
     CONSTRAINT fkuserid FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE NO ACTION ON UPDATE NO ACTION
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX fkcompid_idx ON game_bot_stat (user_id, bot_id);
 
@@ -233,7 +232,7 @@ CREATE TABLE game_participant (
     user_id MEDIUMINT(8) UNSIGNED NOT NULL, 
     bot_id MEDIUMINT(8) UNSIGNED NOT NULL, 
     version_number MEDIUMINT(8) UNSIGNED NOT NULL, 
-    log_name VARCHAR(64), 
+    log_name VARCHAR(256), 
     rank SMALLINT(5) UNSIGNED NOT NULL, 
     player_index SMALLINT(5) UNSIGNED NOT NULL, 
     timed_out TINYINT(1) NOT NULL, 
@@ -241,7 +240,7 @@ CREATE TABLE game_participant (
     CONSTRAINT game_participant_ibfk_4 FOREIGN KEY(game_id) REFERENCES game (id) ON DELETE CASCADE, 
     CONSTRAINT game_participant_ibfk_3 FOREIGN KEY(user_id, bot_id) REFERENCES bot (user_id, id), 
     CONSTRAINT game_participant_ibfk_2 FOREIGN KEY(user_id) REFERENCES user (id)
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX user_id ON game_participant (user_id, bot_id);
 
@@ -259,13 +258,19 @@ CREATE TABLE hackathon_snapshot (
     CONSTRAINT hackathon_snapshot_ibfk_6 FOREIGN KEY(hackathon_id) REFERENCES hackathon (id) ON DELETE CASCADE, 
     CONSTRAINT hackathon_snapshot_ibfk_5 FOREIGN KEY(user_id, bot_id) REFERENCES bot (user_id, id) ON DELETE CASCADE, 
     CONSTRAINT hackathon_snapshot_ibfk_4 FOREIGN KEY(user_id) REFERENCES user (id) ON DELETE CASCADE
-)DEFAULT CHARSET=utf8 ENGINE=InnoDB;
+)ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX user_id ON hackathon_snapshot (user_id, bot_id);
 
 INSERT INTO alembic_version (version_num) VALUES ('7f0054256cf5');
 
--- Running upgrade 7f0054256cf5 -> 33de9025cc63
+-- Running upgrade 7f0054256cf5 -> e7920cc5568a
+
+ALTER TABLE user ADD COLUMN is_gpu_enabled TINYINT(1) NOT NULL DEFAULT '0';
+
+UPDATE alembic_version SET version_num='e7920cc5568a' WHERE alembic_version.version_num = '7f0054256cf5';
+
+-- Running upgrade e7920cc5568a -> 33de9025cc63
 
 ALTER TABLE game_stat DROP FOREIGN KEY game_stat_ibfk_1;
 
@@ -293,11 +298,5 @@ ALTER TABLE game_bot_stat ADD CONSTRAINT game_bot_stat_ibfk_1 FOREIGN KEY(game_i
 
 ALTER TABLE game_participant ADD CONSTRAINT game_participant_ibfk_4 FOREIGN KEY(game_id) REFERENCES game (id) ON DELETE CASCADE;
 
-UPDATE alembic_version SET version_num='33de9025cc63' WHERE alembic_version.version_num = '7f0054256cf5';
-
--- Running upgrade 33de9025cc63 -> e7920cc5568a
-
-ALTER TABLE user ADD COLUMN is_gpu_enabled TINYINT(1) NOT NULL DEFAULT '0';
-
-UPDATE alembic_version SET version_num='e7920cc5568a' WHERE alembic_version.version_num = '33de9025cc63';
+UPDATE alembic_version SET version_num='33de9025cc63' WHERE alembic_version.version_num = 'e7920cc5568a';
 


### PR DESCRIPTION
A couple of changes to match what is actually in the production database.
  * Changes the game_participant.log_name field to VARCHAR(256) from VARCHAR(64).
  * Switches the order of is_gpu_enabled and game.id size alterations as the former was already applied.

Also added `alembic.ini` file which got missed in previous checkins due to `.gitignore` match.

Production database is currently equivalent to the post `is_gpu_enabled` migration state. It does not have the alembic version table though and still needs to have `alembic stamp e7920` run though.