### PR TITLE
py-client: make iteration order over entities in map deterministic

### DIFF
--- a/airesources/ML-StarterBot-Python/hlt/entity.py
+++ b/airesources/ML-StarterBot-Python/hlt/entity.py
@@ -1,8 +1,8 @@
-import math
-
-from . import constants
 import abc
+import math
 from enum import Enum
+from collections import OrderedDict
+from . import constants
 
 
 class Entity:
@@ -104,7 +104,7 @@ class Planet(Entity):
         self.health = hp
         self.owner = owner if bool(int(owned)) else None
         self._docked_ship_ids = docked_ships
-        self._docked_ships = {}
+        self._docked_ships = OrderedDict()
 
     def get_docked_ship(self, ship_id):
         """
@@ -187,7 +187,7 @@ class Planet(Entity):
         """
         num_planets, *remainder = tokens
         num_planets = int(num_planets)
-        planets = {}
+        planets = OrderedDict()
 
         for _ in range(num_planets):
             plid, planet, remainder = Planet._parse_single(remainder)
@@ -344,7 +344,7 @@ class Ship(Entity):
         :return: The dict of Players and unused tokens.
         :rtype: (dict, list[str])
         """
-        ships = {}
+        ships = OrderedDict()
         num_ships, *remainder = tokens
         for _ in range(int(num_ships)):
             ship_id, ships[ship_id], remainder = Ship._parse_single(player_id, remainder)

--- a/airesources/ML-StarterBot-Python/hlt/game_map.py
+++ b/airesources/ML-StarterBot-Python/hlt/game_map.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from . import collision, entity
 
 
@@ -18,8 +19,8 @@ class Map:
         self.my_id = my_id
         self.width = width
         self.height = height
-        self._players = {}
-        self._planets = {}
+        self._players = OrderedDict()
+        self._planets = OrderedDict()
 
     def get_me(self):
         """
@@ -64,7 +65,7 @@ class Map:
         :return: Dict containing all entities with their designated distances
         :rtype: dict
         """
-        result = {}
+        result = OrderedDict()
         for foreign_entity in self._all_ships() + self.all_planets():
             if entity == foreign_entity:
                 continue
@@ -140,7 +141,7 @@ class Player:
     """
     :ivar id: The player's unique id
     """
-    def __init__(self, player_id, ships={}):
+    def __init__(self, player_id, ships=OrderedDict()):
         """
         :param player_id: User's id
         :param ships: Ships user controls (optional)
@@ -187,7 +188,7 @@ class Player:
         """
         num_players, *remainder = tokens
         num_players = int(num_players)
-        players = {}
+        players = OrderedDict()
 
         for _ in range(num_players):
             player, players[player], remainder = Player._parse_single(remainder)

--- a/airesources/Python3/hlt/entity.py
+++ b/airesources/Python3/hlt/entity.py
@@ -1,9 +1,9 @@
 import logging
-import math
-
-from . import constants
 import abc
+import math
 from enum import Enum
+from collections import OrderedDict
+from . import constants
 
 
 class Entity:
@@ -106,7 +106,7 @@ class Planet(Entity):
         self.health = hp
         self.owner = owner if bool(int(owned)) else None
         self._docked_ship_ids = docked_ships
-        self._docked_ships = {}
+        self._docked_ships = OrderedDict()
 
     def get_docked_ship(self, ship_id):
         """
@@ -195,7 +195,7 @@ class Planet(Entity):
         """
         num_planets, *remainder = tokens
         num_planets = int(num_planets)
-        planets = {}
+        planets = OrderedDict()
 
         for _ in range(num_planets):
             plid, planet, remainder = Planet._parse_single(remainder)
@@ -366,7 +366,7 @@ class Ship(Entity):
         :return: The dict of Players and unused tokens.
         :rtype: (dict, list[str])
         """
-        ships = {}
+        ships = OrderedDict()
         num_ships, *remainder = tokens
         for _ in range(int(num_ships)):
             ship_id, ships[ship_id], remainder = Ship._parse_single(player_id, remainder)

--- a/airesources/Python3/hlt/game_map.py
+++ b/airesources/Python3/hlt/game_map.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from . import collision, entity
 
 
@@ -19,8 +20,8 @@ class Map:
         self.my_id = my_id
         self.width = width
         self.height = height
-        self._players = {}
-        self._planets = {}
+        self._players = OrderedDict()
+        self._planets = OrderedDict()
 
     def get_me(self):
         """
@@ -65,7 +66,7 @@ class Map:
         :return: Dict containing all entities with their designated distances
         :rtype: dict
         """
-        result = {}
+        result = OrderedDict()
         for foreign_entity in self._all_ships() + self.all_planets():
             if entity == foreign_entity:
                 continue
@@ -149,7 +150,7 @@ class Player:
     """
     :ivar id: The player's unique id
     """
-    def __init__(self, player_id, ships={}):
+    def __init__(self, player_id, ships=OrderedDict()):
         """
         :param player_id: User's id
         :param ships: Ships user controls (optional)
@@ -198,7 +199,7 @@ class Player:
         """
         num_players, *remainder = tokens
         num_players = int(num_players)
-        players = {}
+        players = OrderedDict()
 
         for _ in range(num_players):
             player, players[player], remainder = Player._parse_single(remainder)


### PR DESCRIPTION
Further progress on the quest for no quant diffs between client languages.