### PR TITLE
Made hlt_client into a pip package

### DIFF
--- a/tools/hlt_client/bin/hlt
+++ b/tools/hlt_client/bin/hlt
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from hlt_client import client
+client.main()

--- a/tools/hlt_client/hlt_client/client.py
+++ b/tools/hlt_client/hlt_client/client.py
@@ -10,8 +10,6 @@ import upload_bot
 import download_game
 import compare_bots
 
-from json.decoder import JSONDecodeError
-
 """client.py: Client for interacting with the Halite II servers."""
 
 __author__ = "Two Sigma"
@@ -109,7 +107,7 @@ class Config:
             config_contents = file.read()
         try:
             return json.loads(config_contents)
-        except (TypeError, JSONDecodeError):
+        except (TypeError, ValueError):
             raise ValueError("Secret formatting has been mangled. Try re-authenticating (`client.py --auth`).")
 
     @staticmethod
@@ -224,7 +222,7 @@ def main():
             compare_bots.play_games(args.halite_binary,
                                     args.map_width, args.map_height,
                                     args.run_commands, args.iterations)
-    except (IndexError, TypeError, ValueError, IOError, FileNotFoundError) as err:
+    except (IndexError, TypeError, ValueError, IOError) as err:
         sys.stderr.write(str(err) + os.linesep)
         exit(-1)
 

--- a/tools/hlt_client/setup.py
+++ b/tools/hlt_client/setup.py
@@ -7,6 +7,7 @@ setup(name='hlt_client',
       author_email='halite@halite.io',
       license='MIT',
       packages=['hlt_client'],
+      scripts=['bin/hlt'],
       install_requires=[
         'requests',
         'zstd',

--- a/website/learn-programming-challenge/halite-cli-and-tools/halite-client-tools.md
+++ b/website/learn-programming-challenge/halite-cli-and-tools/halite-client-tools.md
@@ -6,9 +6,17 @@ sort_key: 9
 ---
 
 
-# Download our CLI
+# Download or install our CLI
 
 [Download: Halite Client](https://storage.cloud.google.com/halite-content/HaliteClient.zip)
+
+or pip install it!
+
+```
+pip install hlt_client
+```
+*Note: if you choose to pip install, replace all references of `./client` below with `hlt`*
+
 
 ## Ready, Set, Authenticate
 


### PR DESCRIPTION
All you need to do now is register it on pip and/or push a new version.

You can install `pip install hlt_client`

After that, instead of doing `./client.py` you can just do `hlt`

How to test:

```
cd tools/hlt_client
pip install --upgrade .
hlt auth
```