### PR TITLE
Fix TypeError while using regex

### DIFF
--- a/airesources/ML-StarterBot-Python/bin/compare_zips.py
+++ b/airesources/ML-StarterBot-Python/bin/compare_zips.py
@@ -15,7 +15,7 @@ def cd(newdir):
     finally:
         os.chdir(prevdir)
 
-def compare(bot1, bot2, binary):
+def compare(bot1, bot2, binary, num_games):
 
     with TemporaryDirectory() as t:
         print("Running in tempdir {}".format(t))
@@ -34,11 +34,10 @@ def compare(bot1, bot2, binary):
             bot1_wins = 0
             bot2_wins = 0
 
-            n = 100
-            print("Starting tournament with {} games".format(n))
+            print("Starting tournament with {} games".format(num_games))
             print("If you visualize the games, Player 1 is purple and Player 2 is teal")
 
-            for i in range(n):
+            for i in range(num_games):
                 cmd = '{} -d "240 160" -t "python3 one/MyBot.py" "python3 two/MyBot.py"'.format(binary)
                 out = subprocess.check_output(cmd, shell=True).decode()
                 # print(out)
@@ -58,8 +57,13 @@ if __name__ == '__main__':
     parser.add_argument("bot1_zip", help="zipfile with the first bot")
     parser.add_argument("bot2_zip", help="zipfile with the second bot")
     parser.add_argument("halite_binary", help="location of halite binary")
+    parser.add_argument("-n", "--num_games", help="number of games to run", required=False, default=100, type=int)
 
     args = parser.parse_args()
 
-    compare(*(os.path.abspath(i) for i in (args.bot1_zip, args.bot2_zip, args.halite_binary)))
+    compare(
+        os.path.abspath(args.bot1_zip),
+        os.path.abspath(args.bot2_zip),
+        os.path.abspath(args.halite_binary),
+        args.num_games)
 

--- a/airesources/ML-StarterBot-Python/bin/compare_zips.py
+++ b/airesources/ML-StarterBot-Python/bin/compare_zips.py
@@ -16,7 +16,7 @@ def cd(newdir):
         os.chdir(prevdir)
 
 def compare(bot1, bot2, binary):
-    
+
     with TemporaryDirectory() as t:
         print("Running in tempdir {}".format(t))
         with cd(t):
@@ -44,22 +44,22 @@ def compare(bot1, bot2, binary):
                 # print(out)
                 # they use player 0 and player 1 instead of 1 and 2 as we do
                 m = re.match("Player #1(.*)came in rank #(\d)", out.splitlines()[-1])
-                bot1_won = (m[2] == '2')
-                if bot1_won: 
-                    bot1_wins += 1 
-                else: 
-                    bot2_wins += 1 
+                bot1_won = (m.groups()[1] == '2')
+                if bot1_won:
+                    bot1_wins += 1
+                else:
+                    bot2_wins += 1
                 print ("Bot1 to Bot2 win ratio is {}:{}".format(bot1_wins, bot2_wins))
 
-                
+
 if __name__ == '__main__':
-    
+
     parser = argparse.ArgumentParser(description="Halite II training")
     parser.add_argument("bot1_zip", help="zipfile with the first bot")
     parser.add_argument("bot2_zip", help="zipfile with the second bot")
     parser.add_argument("halite_binary", help="location of halite binary")
 
     args = parser.parse_args()
-    
+
     compare(*(os.path.abspath(i) for i in (args.bot1_zip, args.bot2_zip, args.halite_binary)))
 


### PR DESCRIPTION
This fixes the following exception:
```
$ ./bin/compare_zips.py submission_2aa1769.zip submission_872523f.zip bin/halite
Running in tempdir /var/folders/x5/vp49cxsx7tz4k874rgrl5ymm0000gn/T/tmpb6vs6ka2
Starting tournament with 100 games
If you visualize the games, Player 1 is purple and Player 2 is teal
Traceback (most recent call last):
  File "./bin/compare_zips.py", line 64, in <module>
    compare(*(os.path.abspath(i) for i in (args.bot1_zip, args.bot2_zip, args.halite_binary)))
  File "./bin/compare_zips.py", line 47, in compare
    bot1_won = (m[2] == '2')
TypeError: '_sre.SRE_Match' object is not subscriptable
```

Here is an excerpt from my pdb session:
```
(Pdb) m
<_sre.SRE_Match object; span=(0, 33), match='Player #1, MyBot, came in rank #2'>
(Pdb) m.groups()
(', MyBot, ', '2')
(Pdb) len(m.groups())
2
(Pdb) m.groups()[1]
'2'
```

Test Plan:
Re-run it and see all 100 games play out.

I have sublime text setup to automatically remove trailing spaces, hence the other lines that got edited.