### PR TITLE
Allow Clojure projects to contain project.clj only

### DIFF
--- a/tools/hlt_client/hlt_client/upload_bot.py
+++ b/tools/hlt_client/hlt_client/upload_bot.py
@@ -5,7 +5,7 @@ import requests
 import client
 
 _BOT_FILE_NAME_PREPEND = 'MyBot.'
-_RUST_BOT_FILE_NAME = 'cargo.toml'
+_LANGUGAGE_PROJECT_FILE_IDENTIFIERS = ['cargo.toml', 'project.clj']
 _HALITE_LIBRARY_FOLDER = 'hlt/'
 
 
@@ -49,7 +49,7 @@ def _zip_file_integrity_check(file_path):
     except FileNotFoundError:
         raise FileNotFoundError("Could not find the zip file provided")
     if not any((item.startswith(_BOT_FILE_NAME_PREPEND)
-                or item.lower() == _RUST_BOT_FILE_NAME) for item in zip.namelist()):
+                or item.lower() in _LANGUGAGE_PROJECT_FILE_IDENTIFIERS) for item in zip.namelist()):
         raise ValueError("MyBot.* file must be present in the zip's top directory (or cargo.toml in case of Rust).")
     if not any(item.lower().startswith(_HALITE_LIBRARY_FOLDER) for item in zip.namelist()):
         sys.stderr.write("WARNING: Could not find an hlt/ library folder. Proceeding with upload. {}".format(os.linesep))

--- a/website/javascript/templates/BotUpload.vue
+++ b/website/javascript/templates/BotUpload.vue
@@ -98,7 +98,8 @@ export default{
         JSZip.loadAsync(this.botFile, () => {
         }).then((zip) => {
           zip.forEach(function (relativePath, zipEntry) {
-            if (zipEntry.name.toLowerCase().startsWith('mybot.') || zipEntry.name.toLowerCase().startsWith('cargo.toml')) {
+            const language_project_file_identifiers = ['cargo.toml', 'project.clj']
+            if (zipEntry.name.toLowerCase().startsWith('mybot.') || language_project_file_identifiers.includes(zipEntry.name.toLowerCase())) {
               my_bot_present = true
             }
           })


### PR DESCRIPTION
With the current client, a Clojure project needs to contain a MyBot.clj at the root of the zip file uploaded to be considered a valid project. However, the current Clojure builder requires you to use Leiningen, and it's not possible to use source code files in the top-level directory. This pull request allows the clients to upload projects that contains a top-level project.clj, which is equivalent to Rust's `cargo.toml`.

I haven't updated error messages and notes that look like
> You should have a `MyBot.{extension for language}` in the root folder of your zip. For Rust, this should be a `cargo.toml`

mostly because I'm unsure how to word it: I'm pretty sure other supported languages also have a setup like Rust and Clojure, but adding a new line saying ```For xxx, this should be a `yyy.zzz` ``` for each of them will make that error message very long.