### PR TITLE
environment: add --no-compression flag to disable compression on hlt …

### DIFF
--- a/environment/core/Halite.cpp
+++ b/environment/core/Halite.cpp
@@ -949,6 +949,7 @@ std::vector<bool> Halite::process_next_frame(std::vector<bool> alive) {
 GameStatistics Halite::run_game(std::vector<std::string>* names_,
                                 unsigned int id,
                                 bool enable_replay,
+                                bool enable_compression,
                                 std::string replay_directory) {
     // For rankings
     std::vector<bool> living_players(number_of_players, true);
@@ -1092,11 +1093,11 @@ GameStatistics Halite::run_game(std::vector<std::string>* names_,
             };
             stats.output_filename = replay_directory + "Replays/" + filename;
             try {
-                replay.output(stats.output_filename);
+                replay.output(stats.output_filename, enable_compression);
             }
             catch (std::runtime_error& e) {
                 stats.output_filename = replay_directory + filename;
-                replay.output(stats.output_filename);
+                replay.output(stats.output_filename, enable_compression);
             }
             if (!quiet_output) {
                 std::cout << "Map seed was " << seed << std::endl

--- a/environment/core/Halite.hpp
+++ b/environment/core/Halite.hpp
@@ -118,6 +118,7 @@ public:
     GameStatistics run_game(std::vector<std::string>* names_,
                             unsigned int id,
                             bool enable_replay,
+                            bool enable_compression,
                             std::string replay_directory);
     std::string get_name(hlt::PlayerId player_tag);
 

--- a/environment/core/Replay.hpp
+++ b/environment/core/Replay.hpp
@@ -32,7 +32,7 @@ struct Replay {
     std::vector<std::vector<std::unique_ptr<Event>>>& full_frame_events;
     std::vector<hlt::MoveQueue>& full_player_moves;
 
-    auto output(std::string filename) -> void;
+    auto output(std::string filename, bool enable_compression) -> void;
 
 private:
     auto output_header(nlohmann::json& replay) -> void;

--- a/environment/main.cpp
+++ b/environment/main.cpp
@@ -116,6 +116,14 @@ int main(int argc, char** argv) {
         false
     );
 
+    TCLAP::SwitchArg noCompressionSwitch(
+        "",
+        "no-compression",
+        "Disables compression for output files.",
+        cmd,
+        false
+    );
+
     //Remaining Args, be they start commands and/or override names. Description only includes start commands since it will only be seen on local testing.
     TCLAP::UnlabeledMultiArg<std::string> otherArgs("NonspecifiedArgs",
                                                     "Start commands for bots.",
@@ -288,6 +296,7 @@ int main(int argc, char** argv) {
     GameStatistics stats = my_game->run_game(names,
                                              id,
                                              !noReplaySwitch.getValue(),
+                                             !noCompressionSwitch.getValue(),
                                              outputFilename);
     if (names != NULL) delete names;
 


### PR DESCRIPTION
As my computer isn't that fast and compression takes up most of the time of one game (especially when there are many ships), I added a switch to disable it. This way the files are considerably bigger, but simulation is faster.