### PR TITLE
Fix running of Haskell bot

### DIFF
--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -420,7 +420,7 @@ languages = (
         (["*.class"], ExternalCompiler(comp_args["Groovy"][1]))]
     ),
     Language("Haskell", BOT, "MyBot.hs",
-        "./MyBot +RTS -M" + str(MEMORY_LIMIT) + "m",
+        "./MyBot",
         [BOT],
         [([""], ExternalCompiler(comp_args["Haskell"][0]))]
     ),

--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -307,7 +307,7 @@ comp_args = {
         ["jar", "cfe", BOT + ".jar", BOT],
     ],
     "Haskell": [
-        ["ghc", "--make", BOT + ".hs", "-O", "-v0"],
+        ["ghc", "--make", BOT + ".hs", "-O", "-v0", "-rtsopts"],
     ],
     "Java": [
         ["javac", "-encoding", "UTF-8", "-J-Xmx%sm" % (MEMORY_LIMIT)],
@@ -420,7 +420,7 @@ languages = (
         (["*.class"], ExternalCompiler(comp_args["Groovy"][1]))]
     ),
     Language("Haskell", BOT, "MyBot.hs",
-        "./MyBot",
+        "./MyBot +RTS -M" + str(MEMORY_LIMIT) + "m",
         [BOT],
         [([""], ExternalCompiler(comp_args["Haskell"][0]))]
     ),


### PR DESCRIPTION
- Avoids the following error "Most RTS options are disabled. Link with -rtsopts to enable them."
- I want to run my bot!