### PR TITLE
Delay sending bot name until ready for first turn in python starter.

### DIFF
--- a/airesources/ML-StarterBot-Python/hlt/networking.py
+++ b/airesources/ML-StarterBot-Python/hlt/networking.py
@@ -14,6 +14,7 @@ class Game:
     def _send_string(s):
         """
         Send data to the game. Call :function:`done_sending` once finished.
+
         :param str s: String to send
         :return: nothing
         """
@@ -24,6 +25,7 @@ class Game:
     def _done_sending():
         """
         Finish sending commands to the game.
+
         :return: nothing
         """
         sys.stdout.write('\n')
@@ -33,6 +35,7 @@ class Game:
     def _get_string():
         """
         Read input from the game.
+
         :return: The input read from the Halite engine
         :rtype: str
         """
@@ -43,6 +46,7 @@ class Game:
     def send_command_queue(command_queue):
         """
         Issue the given list of commands.
+
         :param list[str] command_queue: List of commands to send the Halite engine
         :return: nothing
         """
@@ -55,6 +59,7 @@ class Game:
     def _set_up_logging(tag, name):
         """
         Set up and truncate the log
+
         :param tag: The user tag (used for naming the log)
         :param name: The bot name (used for naming the log)
         :return: nothing
@@ -66,24 +71,30 @@ class Game:
     def __init__(self, name):
         """
         Initialize the bot with the given name.
+
         :param name: The name of the bot.
         """
+        self._name = name
+        self._send_name = False
         tag = int(self._get_string())
         Game._set_up_logging(tag, name)
         width, height = [int(x) for x in self._get_string().strip().split()]
-        self._send_string(name)
-        self._done_sending()
         self.map = game_map.Map(tag, width, height)
         self.update_map()
         self.initial_map = copy.deepcopy(self.map)
+        self._send_name = True
 
     def update_map(self):
         """
         Parse the map given by the engine.
+
         :return: new parsed map
         :rtype: game_map.Map
         """
-        import logging
+        if self._send_name:
+            self._send_string(self._name)
+            self._done_sending()
+            self._send_name = False
         logging.info("---NEW TURN---")
         self.map._parse(self._get_string())
         return self.map

--- a/airesources/Python3/hlt/networking.py
+++ b/airesources/Python3/hlt/networking.py
@@ -74,23 +74,27 @@ class Game:
 
         :param name: The name of the bot.
         """
+        self._name = name
+        self._send_name = False
         tag = int(self._get_string())
         Game._set_up_logging(tag, name)
         width, height = [int(x) for x in self._get_string().strip().split()]
-        self._send_string(name)
-        self._done_sending()
         self.map = game_map.Map(tag, width, height)
         self.update_map()
         self.initial_map = copy.deepcopy(self.map)
+        self._send_name = True
 
     def update_map(self):
         """
         Parse the map given by the engine.
-        
+
         :return: new parsed map
         :rtype: game_map.Map
         """
-        import logging
+        if self._send_name:
+            self._send_string(self._name)
+            self._done_sending()
+            self._send_name = False
         logging.info("---NEW TURN---")
         self.map._parse(self._get_string())
         return self.map


### PR DESCRIPTION
Fixes issue #151 for the python starter bot.