### PR TITLE
re-fix the “Update style of drop downs to be consistent everywhere - …

### DIFF
--- a/website/javascript/templates/Associate.vue
+++ b/website/javascript/templates/Associate.vue
@@ -13,11 +13,16 @@
                     <!-- profession -->
                     <div class="form-group">
                         <label for="country">Which of the following describes you best?<span class="text-danger">*</span></label>
-                        <select class="form-control" id="level" v-model="level">
+                        <!-- <select class="form-control" id="level" v-model="level">
                             <option>Professional</option>
                             <option value="University">University</option>
                             <option value="High School">High school</option>
-                        </select>
+                        </select> -->
+                        <v-select
+                          placeholder="Professional"
+                          v-model="level"
+                          :options="['Professional', 'University', 'High School']">
+                        </v-select>
                     </div>
 
                     <div v-if="level === 'Professional'">


### PR DESCRIPTION
…This is not fixed, I can still see the gray background on professional/university drop down” because it was overridden.

re-fix the “Update style of drop downs to be consistent everywhere - This is not fixed, I can still see the gray background on professional/university drop down” because it was overridden