### PR TITLE
Run API servers with Gunicorn (fixes #147)

### DIFF
--- a/apiserver/requirements.txt
+++ b/apiserver/requirements.txt
@@ -17,6 +17,7 @@ google-cloud-core==0.24.1
 google-cloud-storage==1.1.1
 google-resumable-media==0.0.2
 googleapis-common-protos==1.5.2
+gunicorn==19.7.1
 httplib2==0.10.3
 idna==2.5
 itsdangerous==0.24

--- a/apiserver/setup.sh
+++ b/apiserver/setup.sh
@@ -18,10 +18,10 @@ screen -S sqlproxy -d -m /bin/bash -c \
     "./cloud_sql_proxy -instances=${DB_INSTANCE}=tcp:3307"
 
 screen -S api -d -m /bin/bash -c \
-    "PYTHONPATH=$(pwd) FLASK_APP=apiserver.server flask run -h 0.0.0.0 -p 5000"
+    "PYTHONPATH=$(pwd) gunicorn -w 8 -b 0.0.0.0:5000 --log-level=info apiserver.server:app"
 
 screen -S coordinator_internal -d -m /bin/bash -c \
-    "PYTHONPATH=$(pwd) FLASK_APP=apiserver.coordinator_server flask run -h 0.0.0.0 -p 5001"
+    "PYTHONPATH=$(pwd) gunicorn -w 8 -b 0.0.0.0:5001 --log-level=info apiserver.coordinator_server:app"
 
 screen -S badge_daemon -d -m /bin/bash -c \
     "PYTHONPATH=$(pwd) python3 -m apiserver.scripts.badge_daemon.py"


### PR DESCRIPTION
The Flask built-in server is single threaded, and not production ready. Gunicorn lets us service multiple requests at once. This helps alleviate a small bottleneck in running games, though it's not the root cause of the problem that happened 10/29.