### PR TITLE
update clojure run_game.bat to call lein

### DIFF
--- a/airesources/Clojure/run_game.bat
+++ b/airesources/Clojure/run_game.bat
@@ -1,2 +1,2 @@
-lein uberjar
+call lein uberjar
 halite -d "240 160" "java -jar target/MyBot.jar" "java -jar target/MyBot.jar"


### PR DESCRIPTION
Windows by default transfers execution to a called bat file and does not
return control back when that bat file completes.  Added the call
command to the first line of the bat file so that the second line call
to halite.exe will be executed.

This change fixes #187 