### PR TITLE
Have might_attack take into account ship radius.

### DIFF
--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -172,6 +172,7 @@ auto collision_time(double r, const hlt::Ship& ship1, const hlt::Planet& planet)
 
 auto might_attack(double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool {
     return distance <= ship1.velocity.magnitude() + ship2.velocity.magnitude()
+        + ship1.radius + ship2.radius
         + hlt::GameConstants::get().WEAPON_RADIUS;
 }
 


### PR DESCRIPTION
This fixes the problem where attacks weren't happening until ships were within weapon radius, instead of weapon radius + ship radius * 2.

Reported by @fohristiwhirl at https://forums.halite.io/t/what-are-weapon-ranges-supposed-to-be/417