### PR TITLE
Fixes the collision time calculation

### DIFF
--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -143,23 +143,15 @@ auto collision_time(
         return { true, t };
     }
     else if (disc > 0) {
-        auto t1 = (-b + std::sqrt(disc)) / (2 * a);
-        auto t2 = (-b - std::sqrt(disc)) / (2 * a);
+        const auto t1 = -b + std::sqrt(disc);
+        const auto t2 = -b - std::sqrt(disc);
 
-        // Handle cases where t2 is lower than t1
-        if(t2 < t1) {
-            std::swap(t1, t2);
-        }
-
-        if(t1 >= 0.0 && t1 <= 1.0) {
-            /// t1 is valid to pick, because it is in between 0 and 1
-            return { true, t1 };
-        } else if (t1 <= 0.0 && t2 >= 0.0) {
-            /// t1 is before 0 and t2 is after, but that means at t = 0.0 we are colliding
-            return { true, 0.0 };
+        if (t1 >= 0.0 && t2 >= 0.0) {
+            return { true, std::min(t1, t2) / (2 * a) };
+        } else if (std::min(t1, t2) <= 0.0 && std::max(t1, t2) >= 0.0) {
+            return { true, 0.0}
         } else {
-            /// The range [0, 1] does not intersect with [t1, t2]
-            return { false, 0.0 };
+            return { true, std::max(t1, t2) / (2 * a) };
         }
     }
     else {

--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -143,8 +143,13 @@ auto collision_time(
         return { true, t };
     }
     else if (disc > 0) {
-        const auto t1 = (-b + std::sqrt(disc)) / (2 * a);
-        const auto t2 = (-b - std::sqrt(disc)) / (2 * a);
+        auto t1 = (-b + std::sqrt(disc)) / (2 * a);
+        auto t2 = (-b - std::sqrt(disc)) / (2 * a);
+
+        // Handle cases where t2 is lower than t1
+        if(t2 < t1) {
+            std::swap(t1, t2);
+        }
 
         if(t1 >= 0.0 && t1 <= 1.0) {
             /// t1 is valid to pick, because it is in between 0 and 1

--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -149,7 +149,7 @@ auto collision_time(
         if (t1 >= 0.0 && t2 >= 0.0) {
             return { true, std::min(t1, t2) / (2 * a) };
         } else if (std::min(t1, t2) <= 0.0 && std::max(t1, t2) >= 0.0) {
-            return { true, 0.0}
+            return { true, 0.0 };
         } else {
             return { true, std::max(t1, t2) / (2 * a) };
         }

--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -143,14 +143,18 @@ auto collision_time(
         return { true, t };
     }
     else if (disc > 0) {
-        const auto t1 = -b + std::sqrt(disc);
-        const auto t2 = -b - std::sqrt(disc);
+        const auto t1 = (-b + std::sqrt(disc)) / (2 * a);
+        const auto t2 = (-b - std::sqrt(disc)) / (2 * a);
 
-        if (t1 >= 0.0 && t2 >= 0.0) {
-            return { true, std::min(t1, t2) / (2 * a) };
-        }
-        else {
-            return { true, std::max(t1, t2) / (2 * a) };
+        if(t1 >= 0.0 && t1 <= 1.0) {
+            /// t1 is valid to pick, because it is in between 0 and 1
+            return { true, t1 };
+        } else if (t1 < 0.0 && t2 >= 0.0) {
+            /// t1 is before 0 and t2 is after, but that means at t = 0.0 we are colliding
+            return { true, 0.0 };
+        } else {
+            /// The range [0, 1] does not intersect with [t1, t2]
+            return { false, 0.0 };
         }
     }
     else {

--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -148,10 +148,10 @@ auto collision_time(
 
         if (t1 >= 0.0 && t2 >= 0.0) {
             return { true, std::min(t1, t2) / (2 * a) };
-        } else if (std::min(t1, t2) <= 0.0 && std::max(t1, t2) >= 0.0) {
-            return { true, 0.0 };
-        } else {
+        } else if (t1 <= 0.0 && t2 <= 0.0) {
             return { true, std::max(t1, t2) / (2 * a) };
+        } else {
+            return { true, 0.0 };
         }
     }
     else {

--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -149,7 +149,7 @@ auto collision_time(
         if(t1 >= 0.0 && t1 <= 1.0) {
             /// t1 is valid to pick, because it is in between 0 and 1
             return { true, t1 };
-        } else if (t1 < 0.0 && t2 >= 0.0) {
+        } else if (t1 <= 0.0 && t2 >= 0.0) {
             /// t1 is before 0 and t2 is after, but that means at t = 0.0 we are colliding
             return { true, 0.0 };
         } else {

--- a/environment/core/SimulationEvent.hpp
+++ b/environment/core/SimulationEvent.hpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <unordered_set>
 #include <vector>
+#include <algorithm>
 
 #include "Entity.hpp"
 #include "hlt.hpp"

--- a/environment/core/SimulationEvent.hpp
+++ b/environment/core/SimulationEvent.hpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <unordered_set>
 #include <vector>
-#include <algorithm>
 
 #include "Entity.hpp"
 #include "hlt.hpp"


### PR DESCRIPTION
The collision detection code ignores certain cases. This makes the code over-enthusiastic when saying there is a collision.

Synopsis of fix:
* Calculate t1 and t2 correctly
* The only valid t values are between 0 and 1. Values less than 0 indicate a collision if we went back in time. Values greater than 1 indicate a future collision, but only after the circles would have stopped moving.
