### PR TITLE
Ruby starter: Fix planets' references to docked ships

### DIFF
--- a/airesources/Ruby/hlt/planet.rb
+++ b/airesources/Ruby/hlt/planet.rb
@@ -86,7 +86,7 @@ class Planet < Entity
 
     # Fetch the ship ids from the tokens array
     Integer(ship_count).times do
-      docked_ships << tokens.shift
+      docked_ships << Integer(tokens.shift)
     end
 
     # (id, x, y, hp, radius, docking_spots, owner, docked_ship_ids)


### PR DESCRIPTION
Fixes a string/integer mismatch for a planet's docked ships. 

Planets would have populated ship ids (so that docked ship count was accurate), but would not link these correctly to ship instances.