### PR TITLE
Better API filters

### DIFF
--- a/apiserver/apiserver/web/leaderboard.py
+++ b/apiserver/apiserver/web/leaderboard.py
@@ -96,6 +96,10 @@ def leaderboard():
 
                     if op is operator.ne:
                         clause = ~clause
+                else:
+                    raise util.APIError(
+                        400,
+                        message="Comparison operator not supported for tier field.")
 
                 if tier_filter is None:
                     tier_filter = clause

--- a/apiserver/apiserver/web/util.py
+++ b/apiserver/apiserver/web/util.py
@@ -169,7 +169,12 @@ def parse_filter(filter_string):
     :param filter_string: Of the format field,operator,value.
     :return: (field_name, operator_func, value)
     """
-    field, cmp, value = filter_string.split(",")
+    try:
+        field, cmp, value = filter_string.split(",", 2)
+    except Exception as e:
+        raise util.APIError(
+            400,
+            message="Filter '{}' is ill-formed.".format(filter_string))
 
     operation = {
         "=": operator.eq,


### PR DESCRIPTION
You should be able to do something like `leaderboard?filter=language,contains,C%23` to get all C♯ bots. (Make sure to escape the #.)

Also nicer error messages for ill-formed filters.