### PR TITLE
Fix damage dealt accounting when attacking multiple targets.

### DIFF
--- a/environment/core/Halite.cpp
+++ b/environment/core/Halite.cpp
@@ -715,7 +715,6 @@ auto Halite::process_events() -> void {
             }
 
             target_count[src] = num_prev_targets + 1;
-            damage_dealt[src.player_id()] += hlt::GameConstants::get().WEAPON_DAMAGE;
         };
 
         for (SimulationEvent ev : simultaneous_events) {
@@ -761,6 +760,9 @@ auto Halite::process_events() -> void {
         for (const auto& pair : attackers) {
             full_frame_events.back().push_back(
                 std::unique_ptr<Event>(new AttackEvent(pair.second)));
+            // Track damage dealt here so each attacker's damage is only
+            // counted once.
+            damage_dealt[pair.first.player_id()] += hlt::GameConstants::get().WEAPON_DAMAGE;
             // Use the AttackEvents generated above to actually
             // perform attack calculations. This way, we only perform
             // damage calculations when we're sure there was actually

--- a/environment/version.hpp
+++ b/environment/version.hpp
@@ -3,4 +3,4 @@
 // as linux and macOS.
 
 // Define the version of the executable
-#define HALITE_VERSION "1.3.17.g0246"
+#define HALITE_VERSION "1.3.34.g5378"


### PR DESCRIPTION
Currently a player is counted as dealing full WEAPON_DAMAGE for each pair of ships attacking even when the ship ends up splitting it's attack across multiple targets. This changes it so the WEAPON_DAMAGE is only counted once per ship making an attack. In an example scenario that @shummie found where the starter ships group up and attack each other until 2 of the first and all 3 of the second player have died. In the current counting the players are reported to have dealt 1280 and 1216 damage respectively. With this change the reported damage is 768 and 704 damage.

This will still count all overkill damage, e.g. three ships attacking one ship with only 63 points of health left will count as 64*3 points of damage dealt.