### PR TITLE
Add engine version to replays.

### DIFF
--- a/environment/core/Replay.cpp
+++ b/environment/core/Replay.cpp
@@ -1,4 +1,5 @@
 #include "Replay.hpp"
+#include "../version.hpp"
 
 /**
  * Build up the in-memory representation of the header of the replay.
@@ -7,6 +8,7 @@
  */
 auto Replay::output_header(nlohmann::json& replay) -> void {
     replay["version"] = 31;
+    replay["engine_version"] = HALITE_VERSION;
     replay["seed"] = seed;
     replay["map_generator"] = map_generator;
 

--- a/environment/version.hpp
+++ b/environment/version.hpp
@@ -3,4 +3,4 @@
 // as linux and macOS.
 
 // Define the version of the executable
-#define HALITE_VERSION "1.3.17.g0246"
+#define HALITE_VERSION "1.3.34.g5378"


### PR DESCRIPTION
Add the engine version to replays so that the version of the engine used to create the replay can be found.