### PR TITLE
Portable random number generation

### DIFF
--- a/environment/core/mapgen/SolarSystem.cpp
+++ b/environment/core/mapgen/SolarSystem.cpp
@@ -83,15 +83,15 @@ namespace mapgen {
         const auto min_separation =
             std::sqrt(std::min(map.map_width, map.map_height)) / 1.5;
         auto rand_x_axis = std::bind(
-            std::uniform_int_distribution<int>(1, map.map_width / 2 - 1), std::ref(rng));
+            util::uniform_int_distribution<int>(1, map.map_width / 2 - 1), std::ref(rng));
         auto rand_y_axis = std::bind(
-            std::uniform_int_distribution<int>(1, map.map_height / 2 - 1), std::ref(rng));
+            util::uniform_int_distribution<int>(1, map.map_height / 2 - 1), std::ref(rng));
         auto rand_angle = std::bind(
             std::uniform_real_distribution<double>(0, 2 * M_PI), std::ref(rng));
         auto rand_radius =
             std::bind(std::uniform_real_distribution<double>(min_radius, max_radius), std::ref(rng));
         auto rand_planets_generated =
-            std::bind(std::uniform_int_distribution<>(2, std::max(2, planets_per_player / 2)), std::ref(rng));
+            std::bind(util::uniform_int_distribution<>(2, std::max(2, planets_per_player / 2)), std::ref(rng));
 
         // Temporary storage for the planets created in a particular orbit
         auto planets = std::vector<Zone>();
@@ -215,7 +215,7 @@ namespace mapgen {
         while (extra_planets > 0 && total_attempts < MAX_TOTAL_ATTEMPTS) {
             total_attempts++;
 
-            const auto choice = std::uniform_int_distribution<>(1, 2)(rng);
+            const auto choice = util::uniform_int_distribution<>(1, 2)(rng);
             if (choice == 1) {
                 // Line of planets down vertical axis
                 auto offset = std::uniform_real_distribution<>(max_radius, map.map_height / 2 - max_radius)(rng);

--- a/environment/core/mapgen/SolarSystem.cpp
+++ b/environment/core/mapgen/SolarSystem.cpp
@@ -87,9 +87,9 @@ namespace mapgen {
         auto rand_y_axis = std::bind(
             util::uniform_int_distribution<int>(1, map.map_height / 2 - 1), std::ref(rng));
         auto rand_angle = std::bind(
-            std::uniform_real_distribution<double>(0, 2 * M_PI), std::ref(rng));
+            util::uniform_real_distribution<double>(0, 2 * M_PI), std::ref(rng));
         auto rand_radius =
-            std::bind(std::uniform_real_distribution<double>(min_radius, max_radius), std::ref(rng));
+            std::bind(util::uniform_real_distribution<double>(min_radius, max_radius), std::ref(rng));
         auto rand_planets_generated =
             std::bind(util::uniform_int_distribution<>(2, std::max(2, planets_per_player / 2)), std::ref(rng));
 
@@ -144,7 +144,7 @@ namespace mapgen {
             // docking to a single center planet at the same time
             else if (extra_planets > 1) {
                 const auto radius =
-                    std::uniform_real_distribution<>(small_radius, big_radius)(rng);
+                    util::uniform_real_distribution<>(small_radius, big_radius)(rng);
                 const auto distance_from_center = 2 * radius +
                     2 * hlt::GameConstants::get().SHIP_RADIUS;
 
@@ -218,7 +218,7 @@ namespace mapgen {
             const auto choice = util::uniform_int_distribution<>(1, 2)(rng);
             if (choice == 1) {
                 // Line of planets down vertical axis
-                auto offset = std::uniform_real_distribution<>(max_radius, map.map_height / 2 - max_radius)(rng);
+                auto offset = util::uniform_real_distribution<>(max_radius, map.map_height / 2 - max_radius)(rng);
                 auto radius = rand_radius();
                 auto location1 = hlt::Location{center_x, center_y + offset};
                 auto location2 = hlt::Location{center_x, center_y - offset};
@@ -234,7 +234,7 @@ namespace mapgen {
             }
             else if (choice == 2) {
                 // Line of planets down horizontal axis
-                auto offset = std::uniform_real_distribution<>(max_radius, map.map_width / 2 - max_radius)(rng);
+                auto offset = util::uniform_real_distribution<>(max_radius, map.map_width / 2 - max_radius)(rng);
                 auto radius = rand_radius();
                 auto location1 = hlt::Location{center_x + offset, center_y};
                 auto location2 = hlt::Location{center_x - offset, center_y};
@@ -261,7 +261,7 @@ namespace mapgen {
             const auto small_radius =
                 std::max(2.0, std::sqrt(std::min(map.map_width, map.map_height) / 5));
             const auto radius =
-                std::uniform_real_distribution<>(small_radius, big_radius)(rng);
+                util::uniform_real_distribution<>(small_radius, big_radius)(rng);
             const auto distance_from_center = 2 * radius +
                 2 * hlt::GameConstants::get().SHIP_RADIUS;
 

--- a/environment/core/mapgen/SolarSystem.hpp
+++ b/environment/core/mapgen/SolarSystem.hpp
@@ -2,6 +2,7 @@
 #define HALITE_SOLARSYSTEM_H
 
 #include "Generator.hpp"
+#include "../util/distributions.hpp"
 
 namespace mapgen {
     constexpr auto MAX_TOTAL_ATTEMPTS = 75000;

--- a/environment/core/util/distributions.hpp
+++ b/environment/core/util/distributions.hpp
@@ -1,0 +1,375 @@
+//===----------------------------------------------------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See below for details.
+//
+//===----------------------------------------------------------------------===//
+
+// Derived from Clang libcxx 7e73ea8.
+
+// ==============================================================================
+// libc++ License
+// ==============================================================================
+
+// The libc++ library is dual licensed under both the University of Illinois
+// "BSD-Like" license and the MIT license.  As a user of this code you may choose
+// to use it under either license.  As a contributor, you agree to allow your code
+// to be used under both.
+
+// Full text of the relevant licenses is included below.
+
+// ==============================================================================
+
+// University of Illinois/NCSA
+// Open Source License
+
+// Copyright (c) 2009-2017 by the contributors listed in CREDITS.TXT
+
+// All rights reserved.
+
+// Developed by:
+
+//     LLVM Team
+
+//     University of Illinois at Urbana-Champaign
+
+//     http://llvm.org
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal with
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimers.
+
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//       this list of conditions and the following disclaimers in the
+//       documentation and/or other materials provided with the distribution.
+
+//     * Neither the names of the LLVM Team, University of Illinois at
+//       Urbana-Champaign, nor the names of its contributors may be used to
+//       endorse or promote products derived from this Software without specific
+//       prior written permission.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+// SOFTWARE.
+
+// ==============================================================================
+
+// Copyright (c) 2009-2014 by the contributors listed in CREDITS.TXT
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace util {
+    // Precondition:  __x != 0
+    static unsigned __clz(unsigned __x) {
+#ifndef _LIBCPP_COMPILER_MSVC
+        return static_cast<unsigned>(__builtin_clz(__x));
+#else
+        static_assert(sizeof(unsigned) == sizeof(unsigned long), "");
+        static_assert(sizeof(unsigned long) == 4, "");
+        unsigned long where;
+        // Search from LSB to MSB for first set bit.
+        // Returns zero if no set bit is found.
+        if (_BitScanReverse(&where, mask))
+            return 31 - where;
+        return 32; // Undefined Behavior.
+#endif
+    }
+
+    static unsigned long __clz(unsigned long __x) {
+#ifndef _LIBCPP_COMPILER_MSVC
+        return static_cast<unsigned long>(__builtin_clzl (__x));
+#else
+        static_assert(sizeof(unsigned) == sizeof(unsigned long), "");
+        return __clz(static_cast<unsigned>(__x));
+#endif
+    }
+
+    static unsigned long long __clz(unsigned long long __x) {
+#ifndef _LIBCPP_COMPILER_MSVC
+        return static_cast<unsigned long long>(__builtin_clzll(__x));
+#else
+        unsigned long where;
+        // BitScanReverse scans from MSB to LSB for first set bit.
+        // Returns 0 if no set bit is found.
+#if defined(_LIBCPP_HAS_BITSCAN64)
+        if (_BitScanReverse64(&where, mask))
+            return static_cast<int>(63 - where);
+#else
+        // Scan the high 32 bits.
+        if (_BitScanReverse(&where, static_cast<unsigned long>(mask >> 32)))
+            return 63 - (where + 32); // Create a bit offset from the MSB.
+        // Scan the low 32 bits.
+        if (_BitScanReverse(&where, static_cast<unsigned long>(mask)))
+            return 63 - where;
+#endif
+        return 64; // Undefined Behavior.
+#endif // _LIBCPP_COMPILER_MSVC
+    }
+
+    template <unsigned long long _Xp, std::size_t _Rp>
+    struct __log2_imp
+    {
+        static const std::size_t value = _Xp & ((unsigned long long)(1) << _Rp) ? _Rp
+                                                                      : __log2_imp<_Xp, _Rp - 1>::value;
+    };
+
+    template <unsigned long long _Xp>
+    struct __log2_imp<_Xp, 0>
+    {
+        static const std::size_t value = 0;
+    };
+
+    template <std::size_t _Rp>
+    struct __log2_imp<0, _Rp>
+    {
+        static const std::size_t value = _Rp + 1;
+    };
+
+    template <class _UIntType, _UIntType _Xp>
+    struct __log2
+    {
+        static const std::size_t value = __log2_imp<_Xp,
+                                               sizeof(_UIntType) * __CHAR_BIT__ - 1>::value;
+    };
+
+    template<class _Engine, class _UIntType>
+    class independent_bits_engine
+    {
+    public:
+        // types
+        typedef _UIntType result_type;
+
+    private:
+        typedef typename _Engine::result_type _Engine_result_type;
+        typedef typename std::conditional
+        <
+            sizeof(_Engine_result_type) <= sizeof(result_type),
+                                           result_type,
+                                           _Engine_result_type
+                                           >::type _Working_result_type;
+
+        _Engine& __e_;
+        std::size_t __w_;
+        std::size_t __w0_;
+        std::size_t __n_;
+        std::size_t __n0_;
+        _Working_result_type __y0_;
+        _Working_result_type __y1_;
+        _Engine_result_type __mask0_;
+        _Engine_result_type __mask1_;
+
+        static constexpr const _Working_result_type _Rp = _Engine::max() - _Engine::min()
+            + _Working_result_type(1);
+        static constexpr const std::size_t __m = __log2<_Working_result_type, _Rp>::value;
+        static constexpr const std::size_t _WDt = std::numeric_limits<_Working_result_type>::digits;
+        static constexpr const std::size_t _EDt = std::numeric_limits<_Engine_result_type>::digits;
+
+    public:
+        // constructors and seeding functions
+        independent_bits_engine(_Engine& __e, std::size_t __w);
+
+        // generating functions
+        result_type operator()() {return __eval(std::integral_constant<bool, _Rp != 0>());}
+
+    private:
+        result_type __eval(std::false_type);
+        result_type __eval(std::true_type);
+    };
+
+    template<class _Engine, class _UIntType>
+    independent_bits_engine<_Engine, _UIntType>
+    ::independent_bits_engine(_Engine& __e, std::size_t __w)
+        : __e_(__e),
+          __w_(__w)
+    {
+        __n_ = __w_ / __m + (__w_ % __m != 0);
+        __w0_ = __w_ / __n_;
+        if (_Rp == 0)
+            __y0_ = _Rp;
+        else if (__w0_ < _WDt)
+            __y0_ = (_Rp >> __w0_) << __w0_;
+        else
+            __y0_ = 0;
+        if (_Rp - __y0_ > __y0_ / __n_)
+            {
+                ++__n_;
+                __w0_ = __w_ / __n_;
+                if (__w0_ < _WDt)
+                    __y0_ = (_Rp >> __w0_) << __w0_;
+                else
+                    __y0_ = 0;
+            }
+        __n0_ = __n_ - __w_ % __n_;
+        if (__w0_ < _WDt - 1)
+            __y1_ = (_Rp >> (__w0_ + 1)) << (__w0_ + 1);
+        else
+            __y1_ = 0;
+        __mask0_ = __w0_ > 0 ? _Engine_result_type(~0) >> (_EDt - __w0_) :
+            _Engine_result_type(0);
+        __mask1_ = __w0_ < _EDt - 1 ?
+                           _Engine_result_type(~0) >> (_EDt - (__w0_ + 1)) :
+            _Engine_result_type(~0);
+    }
+
+    template<class _Engine, class _UIntType>
+    inline
+    _UIntType
+    independent_bits_engine<_Engine, _UIntType>::__eval(std::false_type)
+    {
+        return static_cast<result_type>(__e_() & __mask0_);
+    }
+
+    template<class _Engine, class _UIntType>
+    _UIntType
+    independent_bits_engine<_Engine, _UIntType>::__eval(std::true_type)
+    {
+        const std::size_t _WRt = std::numeric_limits<result_type>::digits;
+        result_type _Sp = 0;
+        for (std::size_t __k = 0; __k < __n0_; ++__k)
+            {
+                _Engine_result_type __u;
+                do
+                    {
+                        __u = __e_() - _Engine::min();
+                    } while (__u >= __y0_);
+                if (__w0_ < _WRt)
+                    _Sp <<= __w0_;
+                else
+                    _Sp = 0;
+                _Sp += __u & __mask0_;
+            }
+        for (std::size_t __k = __n0_; __k < __n_; ++__k)
+            {
+                _Engine_result_type __u;
+                do
+                    {
+                        __u = __e_() - _Engine::min();
+                    } while (__u >= __y1_);
+                if (__w0_ < _WRt - 1)
+                    _Sp <<= __w0_ + 1;
+                else
+                    _Sp = 0;
+                _Sp += __u & __mask1_;
+            }
+        return _Sp;
+    }
+
+    template<class _IntType = int>
+    class uniform_int_distribution
+    {
+    public:
+        // types
+        typedef _IntType result_type;
+
+        class param_type
+        {
+            result_type __a_;
+            result_type __b_;
+        public:
+            typedef uniform_int_distribution distribution_type;
+
+            explicit param_type(result_type __a = 0,
+                                result_type __b = std::numeric_limits<result_type>::max())
+                : __a_(__a), __b_(__b) {}
+
+            result_type a() const {return __a_;}
+            result_type b() const {return __b_;}
+
+            friend bool operator==(const param_type& __x, const param_type& __y)
+            {return __x.__a_ == __y.__a_ && __x.__b_ == __y.__b_;}
+            friend bool operator!=(const param_type& __x, const param_type& __y)
+            {return !(__x == __y);}
+        };
+
+    private:
+        param_type __p_;
+
+    public:
+        // constructors and reset functions
+        explicit uniform_int_distribution(result_type __a = 0,
+                                          result_type __b = std::numeric_limits<result_type>::max())
+            : __p_(param_type(__a, __b)) {}
+        explicit uniform_int_distribution(const param_type& __p) : __p_(__p) {}
+        void reset() {}
+
+        // generating functions
+        template<class _URNG> result_type operator()(_URNG& __g)
+        {return (*this)(__g, __p_);}
+        template<class _URNG> result_type operator()(_URNG& __g, const param_type& __p);
+
+        // property functions
+        result_type a() const {return __p_.a();}
+        result_type b() const {return __p_.b();}
+
+        param_type param() const {return __p_;}
+        void param(const param_type& __p) {__p_ = __p;}
+
+        result_type min() const {return a();}
+        result_type max() const {return b();}
+
+        friend bool operator==(const uniform_int_distribution& __x,
+                               const uniform_int_distribution& __y)
+        {return __x.__p_ == __y.__p_;}
+        friend bool operator!=(const uniform_int_distribution& __x,
+                               const uniform_int_distribution& __y)
+        {return !(__x == __y);}
+    };
+
+    template<class _IntType>
+    template<class _URNG>
+    typename uniform_int_distribution<_IntType>::result_type
+    uniform_int_distribution<_IntType>::operator()(_URNG& __g, const param_type& __p)
+    {
+        typedef typename std::conditional<sizeof(result_type) <= sizeof(std::uint32_t),
+            uint32_t, uint64_t>::type _UIntType;
+        const _UIntType _Rp = __p.b() - __p.a() + _UIntType(1);
+        if (_Rp == 1)
+            return __p.a();
+        const std::size_t _Dt = std::numeric_limits<_UIntType>::digits;
+        typedef independent_bits_engine<_URNG, _UIntType> _Eng;
+        if (_Rp == 0)
+            return static_cast<result_type>(_Eng(__g, _Dt)());
+        std::size_t __w = _Dt - __clz(_Rp) - 1;
+        if ((_Rp & (std::numeric_limits<_UIntType>::max() >> (_Dt - __w))) != 0)
+            ++__w;
+        _Eng __e(__g, __w);
+        _UIntType __u;
+        do
+            {
+                __u = __e();
+            } while (__u >= _Rp);
+        return static_cast<result_type>(__u + __p.a());
+    }
+}

--- a/environment/core/util/distributions.hpp
+++ b/environment/core/util/distributions.hpp
@@ -379,11 +379,7 @@ namespace util {
     {
         const std::size_t _Dt = std::numeric_limits<_RealType>::digits;
         const std::size_t __b = _Dt < __bits ? _Dt : __bits;
-#ifdef _LIBCPP_CXX03_LANG
-        const std::size_t __logR = __log2<uint64_t, _URNG::_Max - _URNG::_Min + uint64_t(1)>::value;
-#else
         const std::size_t __logR = __log2<uint64_t, _URNG::max() - _URNG::min() + uint64_t(1)>::value;
-#endif
         const std::size_t __k = __b / __logR + (__b % __logR != 0) + (__b == 0);
         const _RealType _Rp = _URNG::max() - _URNG::min() + _RealType(1);
         _RealType __base = _Rp;

--- a/environment/main.cpp
+++ b/environment/main.cpp
@@ -6,6 +6,7 @@
 
 #include "version.hpp"
 #include "core/Halite.hpp"
+#include "core/util/distributions.hpp"
 
 inline std::istream& operator>>(std::istream& i,
                                 std::pair<signed int, signed int>& p) {
@@ -193,7 +194,7 @@ int main(int argc, char** argv) {
         std::vector<unsigned short> mapSizeChoices =
             { 80, 80, 88, 88, 96, 96, 96, 104, 104, 104, 112, 112, 112, 120, 120, 128, 128 };
         std::mt19937 prg(seed);
-        std::uniform_int_distribution<unsigned long> size_dist(0, mapSizeChoices.size() - 1);
+        util::uniform_int_distribution<unsigned long> size_dist(0, mapSizeChoices.size() - 1);
         auto mapBase = mapSizeChoices[size_dist(prg)];
         mapWidth = 3 * mapBase;
         mapHeight = 2 * mapBase;

--- a/environment/make.bat
+++ b/environment/make.bat
@@ -7,6 +7,7 @@ CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd6
 cl.exe /std:c++14 /O2 /MT /EHsc /W2 /Fo.\obj\ /Fehalite.exe ^
  ^
  /DZSTD_MULTITHREAD=1 ^
+ /D_LIBCPP_COMPILER_MSVC=1 ^
  /DNDEBUG ^
  ^
  /I . ^

--- a/environment/make2017.bat
+++ b/environment/make2017.bat
@@ -10,6 +10,7 @@ CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary
 cl.exe /std:c++14 /O2 /MT /EHsc /W2 /Fo.\obj\ /Fehalite.exe ^
  ^
  /DZSTD_MULTITHREAD=1 ^
+ /D_LIBCPP_COMPILER_MSVC=1 ^
  /DNDEBUG ^
  ^
  /I . ^

--- a/environment/make2017_32.bat
+++ b/environment/make2017_32.bat
@@ -10,6 +10,7 @@ CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary
 cl.exe /std:c++14 /O2 /MT /EHsc /W2 /Fo.\obj\ /Fehalite.exe ^
  ^
  /DZSTD_MULTITHREAD=1 ^
+ /D_LIBCPP_COMPILER_MSVC=1 ^
  /DNDEBUG ^
  ^
  /I . ^


### PR DESCRIPTION
Pulls the Clang libcxx implementation of `uniform_int_distribution` and `uniform_real_distribution` (MIT license) into the engine itself, hopefully giving us deterministic random number generation across platforms.