### PR TITLE
Increase SERIALIZATION_PRECISION to 6

### DIFF
--- a/environment/networking/Networking.hpp
+++ b/environment/networking/Networking.hpp
@@ -32,7 +32,7 @@ extern bool quiet_output;
 /**
  * How many digits of precision to send to the client.
  */
-constexpr auto SERIALIZATION_PRECISION = 4;
+constexpr auto SERIALIZATION_PRECISION = 6;
 
 constexpr auto INIT_TIME_LIMIT = std::chrono::seconds{60};
 constexpr auto FRAME_TIME_LIMIT = std::chrono::milliseconds{2000};


### PR DESCRIPTION
I don't see any real downside to this. This number only determines the precision sent to the clients, it doesn't affect replays.

We could even go higher e.g. 8 or 10. But I suppose it's nice to be able to look at the comms visually if one wants to understand the format (e.g. [I did so here](https://forums.halite.io/t/halite-comms-protocol-explained/411/1)). So perhaps 6 is fine.