### PR TITLE
hardening local imports

### DIFF
--- a/tools/hlt_client/hlt_client/client.py
+++ b/tools/hlt_client/hlt_client/client.py
@@ -6,9 +6,9 @@ import sys
 import json
 import argparse
 
-import upload_bot
-import download_game
-import compare_bots
+from . import upload_bot
+from . import download_game
+from . import compare_bots
 
 """client.py: Client for interacting with the Halite II servers."""
 

--- a/tools/hlt_client/hlt_client/download_game.py
+++ b/tools/hlt_client/hlt_client/download_game.py
@@ -6,7 +6,7 @@ import requests
 import multiprocessing
 from concurrent.futures.thread import ThreadPoolExecutor
 
-import client
+from . import client
 
 _ITEMS_KEY = 'items'
 _SELFLINK_KEY = 'selfLink'

--- a/tools/hlt_client/hlt_client/upload_bot.py
+++ b/tools/hlt_client/hlt_client/upload_bot.py
@@ -2,7 +2,8 @@ import os
 import sys
 import zipfile
 import requests
-import client
+
+from . import client
 
 _BOT_FILE_NAME_PREPEND = 'MyBot.'
 _LANGUGAGE_PROJECT_FILE_IDENTIFIERS = ['cargo.toml', 'project.clj', 'package.swift']


### PR DESCRIPTION
To make sure the imported module is local one.

I have to made these changes to be able to create a Nix package on my [fork](https://github.com/wizzup/Halite-II/tree/nix/tools/hlt_client).
