### PR TITLE
`hlt replay` saving as valid json

### DIFF
--- a/tools/hlt_client/hlt_client/download_game.py
+++ b/tools/hlt_client/hlt_client/download_game.py
@@ -62,7 +62,7 @@ class GameDownloader:
         :return: the file unzipped if possible
         """
         try:
-            return str(zstd.loads(game_binary))
+            return zstd.loads(game_binary).decode()
         except Exception:
             raise ValueError("Could not unzip file at: {}!".format(game_id))
 
@@ -199,4 +199,3 @@ def download(mode, destination, date, all_bots, default_user_id, user_id, limit)
             raise ValueError("Cannot run default mode without authenticating .Please run `client.py --auth` first.")
         UserGameDownloader(destination, default_user_id if not user_id else user_id, limit).get_objects()
     print('Finished writing files to desired location')
-


### PR DESCRIPTION
I believe this is the underlying issue for #71. The `hlt` client doesn't save valid json.

Previously binary strings were being cast to a string using `str`. This generates the string
```
b'{ real_json}'
```
The binary string needs to be decoded rather than cast. This results in the value
```
{ real_json }
```
The [work around](https://forums.halite.io/t/how-do-you-open-hlt-files/243/2?u=kjschiroo) the community has been using is to remove the first 2 and last byte, then parse it.