### PR TITLE
Record all player stats in replay file.

### DIFF
--- a/environment/core/Statistics.cpp
+++ b/environment/core/Statistics.cpp
@@ -6,6 +6,11 @@ auto to_json(nlohmann::json& json, const GameStatistics& stats) -> void {
         auto& player_stats = stats.player_statistics[player_id];
         json[std::to_string(static_cast<int>(player_id))] = nlohmann::json{
             { "rank", player_stats.rank },
+            { "last_frame_alive", player_stats.last_frame_alive },
+            { "total_ship_count", player_stats.total_ship_count },
+            { "damage_dealt", player_stats.damage_dealt },
+            { "init_response_time", player_stats.init_response_time },
+            { "average_frame_response_time", player_stats.average_frame_response_time },
         };
     }
 }


### PR DESCRIPTION
This records all of the player statistics tracked by the engine in the replay. Probably most useful is that it allows easy checking of the less obvious win condition parameters (ships produced and damage dealt) for each player.