### PR TITLE
Remove mentions of run.sh.

### DIFF
--- a/website/learn-programming-challenge/downloads-and-starter-kits/customize-bot.md
+++ b/website/learn-programming-challenge/downloads-and-starter-kits/customize-bot.md
@@ -74,10 +74,3 @@ See the [Game Server Reference](/learn-programming-challenge/other-resources/gam
 
 For JVM languages, you can submit a jar file inside of your zip file instead of source files. The jar will be executed `java -jar MyBot.jar` so you need to define a Main-Class header in the manifest.
 
-## Custom run script
-
-You may supply a `run.sh` script to control how your bot is run. Many languages will be properly auto detected and run without the need for an `run.sh` script. You should only include a custom `run.sh` script if you have a real need for one.
-
-You could use a `run.sh` file to use a custom runtime such as `PyPy` instead of the default `Python 3`.
-
-

--- a/website/learn-programming-challenge/downloads-and-starter-kits/debug-bot.md
+++ b/website/learn-programming-challenge/downloads-and-starter-kits/debug-bot.md
@@ -14,7 +14,7 @@ If you bot fails compilation, you will get an email to that effect. The most com
 
 1. **Incorrect bot archive structure:** If you don't adhere to the guidelines specified in our [submit a bot guide](submit-bot) guide, your bot will fail to compile and you will get an email to that effect. Once you fix up your bot submission structure, this issue should resolve automatically.
 
-2. **Infrastructure Issues:** If you are submitting a bot in a unsupported language or trying to use a library/dependency that is not pre-installed on our servers, you will have to either add a custom `install.sh` and `run.sh` script to add these dependencies, and start your bot with a custom runtime. You can also reach out to the [Halite Team](mailto:halite@halite.io) to add first class support for your bot. To read more about customizing a bot, checkout out our guide [here](customize-bot).
+2. **Infrastructure Issues:** You can reach out to the [Halite Team](mailto:halite@halite.io) to add first class support for your bot. To read more about customizing a bot, checkout out our guide [here](customize-bot).
 
 3. **Compilation errors in your code:** Make sure that you can compile your bot locally before submitting it to our game servers. If the bot compiles on your local machine but fails in our servers, it will be mostly due to the issues enumerated in 2).
 


### PR DESCRIPTION
As `run.sh` isn't fully implemented (and never was from what I can find) this removes mention of it from the documentation so that people aren't led astray trying to make it work.