### PR TITLE
Properly kill child processes

### DIFF
--- a/environment/networking/Networking.cpp
+++ b/environment/networking/Networking.cpp
@@ -695,7 +695,7 @@ void Networking::kill_player(hlt::PlayerId player_tag) {
         } else break;
     }
 
-    kill(-processes[player_tag], SIGKILL);
+    kill(processes[player_tag], SIGKILL);
 
     processes[player_tag] = -1;
     connections[player_tag].read = -1;


### PR DESCRIPTION
Process kill call was negating the pid, and not properly killing children.