### PR TITLE
adds gradle task to build submittable zip

### DIFF
--- a/airesources/Kotlin/build.gradle
+++ b/airesources/Kotlin/build.gradle
@@ -32,3 +32,11 @@ jar {
     archiveName 'MyBot.jar'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }
+
+task submission(type: Zip) {
+    from 'build/libs/MyBot.jar'
+    from 'LANGUAGE'
+    archiveName 'submission.zip'
+}
+
+submission.dependsOn jar


### PR DESCRIPTION
By running the gradle submission task the submittable zip file is outputted to /build/distributions