### PR TITLE
Perform internal computations in long double

### DIFF
--- a/environment/core/Entity.cpp
+++ b/environment/core/Entity.cpp
@@ -2,11 +2,11 @@
 #include "hlt.hpp"
 
 namespace hlt {
-    auto Location::distance(const Location &other) const -> double {
+    auto Location::distance(const Location &other) const -> long double {
         return sqrt(distance2(other));
     }
 
-    auto Location::distance2(const Location &other) const -> double {
+    auto Location::distance2(const Location &other) const -> long double {
         return std::pow(other.pos_x - pos_x, 2) +
             std::pow(other.pos_y - pos_y, 2);
     }
@@ -47,7 +47,7 @@ namespace hlt {
         }
     }
 
-    auto Velocity::magnitude() const -> double {
+    auto Velocity::magnitude() const -> long double {
         return sqrt(vel_x * vel_x + vel_y * vel_y);
     }
 

--- a/environment/core/Entity.hpp
+++ b/environment/core/Entity.hpp
@@ -40,10 +40,10 @@ namespace hlt {
     using possibly = std::pair<T, bool>;
 
     struct Velocity {
-        double vel_x, vel_y;
+        long double vel_x, vel_y;
 
         auto accelerate_by(double magnitude, double angle) -> void;
-        auto magnitude() const -> double;
+        auto magnitude() const -> long double;
         auto angle() const -> double;
     };
 
@@ -51,10 +51,10 @@ namespace hlt {
      * A location in Halatian space.
      */
     struct Location {
-        double pos_x, pos_y;
+        long double pos_x, pos_y;
 
-        auto distance(const Location& other) const -> double;
-        auto distance2(const Location& other) const -> double;
+        auto distance(const Location& other) const -> long double;
+        auto distance2(const Location& other) const -> long double;
 
         auto move_by(const Velocity& velocity, double time) -> void;
         auto angle_to(const Location& target) const -> double;

--- a/environment/core/SimulationEvent.cpp
+++ b/environment/core/SimulationEvent.cpp
@@ -98,7 +98,7 @@ auto CollisionMap::test(const hlt::Location& location, double radius,
 }
 
 auto collision_time(
-    double r,
+    long double r,
     const hlt::Location& loc1, const hlt::Location& loc2,
     const hlt::Velocity& vel1, const hlt::Velocity& vel2
 ) -> std::pair<bool, double> {
@@ -159,25 +159,25 @@ auto collision_time(
     }
 }
 
-auto collision_time(double r, const hlt::Ship& ship1, const hlt::Ship& ship2) -> std::pair<bool, double> {
+auto collision_time(long double r, const hlt::Ship& ship1, const hlt::Ship& ship2) -> std::pair<bool, long double> {
     return collision_time(r,
                           ship1.location, ship2.location,
                           ship1.velocity, ship2.velocity);
 }
 
-auto collision_time(double r, const hlt::Ship& ship1, const hlt::Planet& planet) -> std::pair<bool, double> {
+auto collision_time(long double r, const hlt::Ship& ship1, const hlt::Planet& planet) -> std::pair<bool, long double> {
     return collision_time(r,
                           ship1.location, planet.location,
                           ship1.velocity, { 0, 0 });
 }
 
-auto might_attack(double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool {
+auto might_attack(long double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool {
     return distance <= ship1.velocity.magnitude() + ship2.velocity.magnitude()
         + ship1.radius + ship2.radius
         + hlt::GameConstants::get().WEAPON_RADIUS;
 }
 
-auto might_collide(double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool {
+auto might_collide(long double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool {
     return distance <= ship1.velocity.magnitude() + ship2.velocity.magnitude() +
         ship1.radius + ship2.radius;
 }

--- a/environment/core/SimulationEvent.hpp
+++ b/environment/core/SimulationEvent.hpp
@@ -85,10 +85,10 @@ auto collision_time(
     const hlt::Location& loc1, const hlt::Location& loc2,
     const hlt::Velocity& vel1, const hlt::Velocity& vel2
 ) -> std::pair<bool, double>;
-auto collision_time(double r, const hlt::Ship& ship1, const hlt::Ship& ship2) -> std::pair<bool, double>;
-auto collision_time(double r, const hlt::Ship& ship1, const hlt::Planet& ship2) -> std::pair<bool, double>;
-auto might_attack(double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool;
-auto might_collide(double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool;
+auto collision_time(long double r, const hlt::Ship& ship1, const hlt::Ship& ship2) -> std::pair<bool, long double>;
+auto collision_time(long double r, const hlt::Ship& ship1, const hlt::Planet& ship2) -> std::pair<bool, long double>;
+auto might_attack(long double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool;
+auto might_collide(long double distance, const hlt::Ship& ship1, const hlt::Ship& ship2) -> bool;
 auto round_event_time(double t) -> double;
 
 auto find_events(

--- a/environment/core/json.hpp
+++ b/environment/core/json.hpp
@@ -8328,7 +8328,7 @@ class basic_json
             }
 
             // get number of digits for a text -> float -> text round-trip
-            static constexpr auto d = std::numeric_limits<NumberType>::digits10;
+            static constexpr auto d = std::numeric_limits<NumberType>::max_digits10;
 
             // the actual conversion
             const auto written_bytes = snprintf(m_buf.data(), m_buf.size(), "%.*g", d, x);


### PR DESCRIPTION
This is an attempted fix for #135. However, it makes the values in the replay quite misleading; under the case that @shummie submitted, while the engine now correctly computes that ships 9 and 11 are far enough apart to not collide, the values in the JSON suggest they should have collided, even with the tweak suggested in https://github.com/nlohmann/json/issues/360.