### PR TITLE
dlang: statically disable logger during compilation

### DIFF
--- a/apiserver/worker/compiler.py
+++ b/apiserver/worker/compiler.py
@@ -333,7 +333,7 @@ comp_args = {
         ["g++", "-O2", "-lm", "-std=c++11", "-o", BOT],
     ],
     "D": [
-        ["dmd", "-O", "-inline", "-release", "-noboundscheck", "-of" + BOT],
+        ["dmd", "-O", "-inline", "-release", "-noboundscheck", "-version=StdLoggerDisableLogging", "-of" + BOT],
     ],
     "Elixir": [
         ["yes", "|", "mix", "deps.get"],


### PR DESCRIPTION
Adding the flag -version=StdLoggerDisableLogging to the compiler will statically disable all logging for bots written in D (see https://dlang.org/phobos/std_experimental_logger.html), improving the speed of the final build. This allows uploading a bot without scrubbing away logging used during development.