### PR TITLE
Fix missing div end tag in hackathon portal.

### DIFF
--- a/website/javascript/templates/HackathonPortal.vue
+++ b/website/javascript/templates/HackathonPortal.vue
@@ -54,8 +54,8 @@
             </div>
           </div> 
         </div> 
-      </div>
-    </div>-->
+      </div> -->
+    </div>
     <div class="hackathon-events-container" v-show="showEvents">
       <div class="hackathon-title">
         <i class="xline xline-top"></i>


### PR DESCRIPTION
It looks like one too many div end tags were commented out.

Currently with the missing `</div>` the `hackathon-events-container` ends up as a child of the `hackathon-in-progress-container`, where I'm pretty sure they are suppose to be siblings. If it really is suppose to be a child then the missing `</div>` needs to be added with the end group of closing tags.

Mostly I'm fixing to stop the warning from jekyll. ;)