### PR TITLE
Override hlt_client config directory with environment variable

### DIFF
--- a/tools/hlt_client/hlt_client/client.py
+++ b/tools/hlt_client/hlt_client/client.py
@@ -27,6 +27,8 @@ URI_API_EXISTING_BOT = URI_HALITE_API + "/user/{}/bot/{}"
 URI_HALITE_WEB_PAGE = 'http://halite.io'
 URI_WEB_API_KEY = "{}/user/settings".format(URI_HALITE_WEB_PAGE)
 
+CONFIG_DIR = 'HALITE_CONFIG_DIR'
+
 SUCCESS = 200
 FIRST_BOT_ID = 0
 BOT_FILE_KEY = 'botFile'
@@ -65,11 +67,19 @@ class Config:
     @staticmethod
     def _get_config_folder_path():
         """
-        Returns system specific folder for config
+        Returns the folder for config.
+
         :return:  %LOCALAPPDATA%/Halite if windows ~/.config/hlt otherwise
+                  The HALITE_CONFIG_DIR environment variable overrides
+                  these defaults. If set, returns its value.
         """
-        return "{}/Halite".format(os.getenv('LOCALAPPDATA')) if sys.platform == 'win32' \
-            else "{}/.config/hlt".format(os.path.expanduser("~"))
+        if os.getenv(CONFIG_DIR):
+            return os.getenv(CONFIG_DIR)
+
+        if sys.platform == 'win32':
+            return "{}/Halite".format(os.getenv('LOCALAPPDATA'))
+
+        return "{}/.config/hlt".format(os.path.expanduser("~"))
 
     @staticmethod
     def _get_auth_file_path():


### PR DESCRIPTION
Allow the HALITE_CONFIG_DIR environment variable value to override
the system-specific configuration directories. One motivation for
this is to allow a number of users to use the same collaboration
environment (a common system user account), such as at a meetup,
with a number of Halite accounts.