### PR TITLE
Change to new player seeding to be based off of games played.

### DIFF
--- a/apiserver/apiserver/coordinator/matchmaking.py
+++ b/apiserver/apiserver/coordinator/matchmaking.py
@@ -387,13 +387,8 @@ def find_seed_player(conn, ranked_users, seed_filter):
     if not config.COMPETITION_FINALS_PAIRING:
         rand_value = random.random()
 
-        if rand_value > 0.5:
-            logging.info("Matchmaking: seed player: looking for random bot"
-                         " with fewest games played")
-            result = find_newbie_seed_player(conn, ranked_users, seed_filter)
-            if result:
-                return result
-        elif 0.25 < rand_value <= 0.5:
+        # Give 25% of games to least recently played new players
+        if rand_value > 0.75:
             logging.info("Matchmaking: seed player: looking for random bot"
                          " with under 400 games played that hasn't played"
                          " recently")
@@ -401,10 +396,17 @@ def find_seed_player(conn, ranked_users, seed_filter):
                                              restrictions=True)
             if result:
                 return result
+        # Give 65% of games to lowest games played
+        # (also take any games where a seed isn't found above, almost certainly
+        #  because everyone is over 400 games)
+        if rand_value > 0.1:
+            logging.info("Matchmaking: seed player: looking for random bot"
+                         " with fewest games played")
+            result = find_newbie_seed_player(conn, ranked_users, seed_filter)
+            if result:
+                return result
 
-        # Fallback case
-        # Same as the previous case, but we do not restrict how many
-        # games the user can have played, and we do not sort randomly.
+        # Give 10% of games to overall user who has least recently played
         logging.info("Matchmaking: seed player: looking for random bot"
                      " that hasn't played recently")
         result = find_idle_seed_player(conn, ranked_users, seed_filter,

--- a/apiserver/apiserver/coordinator/matchmaking.py
+++ b/apiserver/apiserver/coordinator/matchmaking.py
@@ -343,7 +343,13 @@ def find_newbie_seed_player(conn, ranked_users, seed_filter):
     :return:
     """
     sqlfunc = sqlalchemy.sql.func
-    ordering = sqlfunc.rand() * -sqlfunc.pow(model.bots.c.sigma, 2)
+    game_curve = 1 / (model.bots.c.games_played + 1)
+    # weight the curve between half and full weight
+    rand_factor = 0.5 + (sqlfunc.rand() * 0.5)
+    # Since the curve is cut in half every doubling of games, this means a bot
+    # will always be chosen ahead of any bots that have more than twice the
+    # number of games
+    ordering = rand_factor * -game_curve
     query = sqlalchemy.sql.select([
         ranked_users.c.user_id,
         model.bots.c.id.label("bot_id"),
@@ -363,9 +369,9 @@ def find_newbie_seed_player(conn, ranked_users, seed_filter):
         )
     ).where(
         (model.bots.c.compile_status == model.CompileStatus.SUCCESSFUL.value) &
-        (model.bots.c.games_played < 400) &
         seed_filter
-    ).order_by(ordering).limit(1).reduce_columns()
+    ).order_by(ordering).limit(20).reduce_columns().alias("seed_query").select(
+    ).order_by(sqlfunc.rand())
 
     return conn.execute(query).first()
 
@@ -383,13 +389,14 @@ def find_seed_player(conn, ranked_users, seed_filter):
 
         if rand_value > 0.5:
             logging.info("Matchmaking: seed player: looking for random bot"
-                         " with under 400 games played")
+                         " with fewest games played")
             result = find_newbie_seed_player(conn, ranked_users, seed_filter)
             if result:
                 return result
         elif 0.25 < rand_value <= 0.5:
             logging.info("Matchmaking: seed player: looking for random bot"
-                         " from recent game with under 400 games played")
+                         " with under 400 games played that hasn't played"
+                         " recently")
             result = find_idle_seed_player(conn, ranked_users, seed_filter,
                                              restrictions=True)
             if result:
@@ -399,7 +406,7 @@ def find_seed_player(conn, ranked_users, seed_filter):
         # Same as the previous case, but we do not restrict how many
         # games the user can have played, and we do not sort randomly.
         logging.info("Matchmaking: seed player: looking for random bot"
-                     " from recent game")
+                     " that hasn't played recently")
         result = find_idle_seed_player(conn, ranked_users, seed_filter,
                                          restrictions=False)
         if result:


### PR DESCRIPTION
This changes the 'new' player seeding to be based off of games played instead of sigma. This then allows the 400 game limit for this seeding to be removed. The 400 game limit was imposed because there are certain situations where sigma does not go down with additional games played. In fact the problem that caused it to get added had sigma continually increasing.

The sigma based seeding with a 400 game limit wasn't too bad before because there was always a number of players under 400 games, but now that there are significant chunks of time where all players have over 400 games it is becoming a problem.

This also reduces the least recently played seed to be chosen 10% of the time from 25%. From my testing this is still enough to ensure that all bots get enough games to keep their rating in line.

The seeding selection based on games is set up to roughly match the distribution that the sigma based selection used. Specifically early sigma is roughly 8.333 / (games + 1)**0.55, the old seed selection then squared that sigma. This approximately reduces to 1 / (games + 1).

Besides significantly and purposefully changing the game distribution when there are no players under 400 games, this will somewhat change the game distribution when there are players with under 400 games. Probably most significantly players will not see a large a drop off in game rate after passing the 400 game mark but instead a gradual decrease as the game count increases. Overall players from 400 to ~800 will see an increased rate of games played and players with a large number of games (>1200) will generally receive less games.