### PR TITLE
Remove mysql gtid purged info from schema.

### DIFF
--- a/apiserver/sql/generate_schema.sh
+++ b/apiserver/sql/generate_schema.sh
@@ -24,5 +24,5 @@ else
     PASS_OPT="--password=$DB_PASS"
 fi
 
-mysqldump --host=$DB_HOST --port=$DB_PORT --user=$DB_USER $PASS_OPT --no-data $DB_NAME
-mysqldump --host=$DB_HOST --port=$DB_PORT --user=$DB_USER $PASS_OPT $DB_NAME --no-create-info alembic_version
+mysqldump --host=$DB_HOST --port=$DB_PORT --user=$DB_USER $PASS_OPT --no-data --set-gtid-purged=off $DB_NAME
+mysqldump --host=$DB_HOST --port=$DB_PORT --user=$DB_USER $PASS_OPT $DB_NAME --no-create-info --set-gtid-purged=off alembic_version

--- a/apiserver/sql/schema.sql
+++ b/apiserver/sql/schema.sql
@@ -18,12 +18,6 @@ SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN;
 SET @@SESSION.SQL_LOG_BIN= 0;
 
 --
--- GTID state at the beginning of the backup 
---
-
-SET @@GLOBAL.GTID_PURGED='397d1add-5cc9-11e7-9997-42010a8e0fdd:1-62888918';
-
---
 -- Table structure for table `alembic_version`
 --
 
@@ -522,12 +516,6 @@ SET @@SESSION.SQL_LOG_BIN = @MYSQLDUMP_TEMP_LOG_BIN;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN;
 SET @@SESSION.SQL_LOG_BIN= 0;
-
---
--- GTID state at the beginning of the backup 
---
-
-SET @@GLOBAL.GTID_PURGED='397d1add-5cc9-11e7-9997-42010a8e0fdd:1-62888958';
 
 --
 -- Dumping data for table `alembic_version`


### PR DESCRIPTION
Removes the GTID_PURGED setting from the saved schema. It is irrelevant for the schema and mildly annoying when creating a new database using the `schema.sql` file.