### PR TITLE
Implement various things for finals

### DIFF
--- a/apiserver/apiserver/config.py
+++ b/apiserver/apiserver/config.py
@@ -4,6 +4,34 @@ from passlib.context import CryptContext
 COMPETITION_OPEN = True
 # Original PHP: "compState", "finalsPairing"
 COMPETITION_FINALS_PAIRING = False
+# Final open game id, set this to the id of last game played in the open stage
+LAST_OPEN_GAME = None
+# Rank cutoff schedule during finals
+# In each entry the first value is number of games to start the cutoff and
+# second value is the rank cutoff to use.
+# Following schedule is based on ~4000 bots for 6 days of ~3000 games per hour
+FINALS_CUTOFF_SCHEDULE = [
+    (0, 4500),     # cutoff initially higher than total number of bots
+    (42000, 3500), # All bots should now have 30 games at 14 hours in
+    (66000, 2600), # At the start of this phase remaining bots have 50 games
+    (75000, 1700), # end of starter bots, 60 games, 25 hours
+    (127000, 1000), # 150 games, 42 hours
+    (178000, 500), # 300 games, 2.5 days
+    (229000, 250), # 600 games, 3 days
+    (280000, 150), # 1200 games, 4 days
+] # at 6 days the top bots should have 4200+ games with 432000 games in finals
+# Alternative example schedule for 5000 bots
+_5000_schedule = [ # For 5000 bots, 6 days, 3000 gph
+    (0, 5500),
+    (53000, 4000), # All bots should now have 30 games at 17.5 hours in
+    (81000, 3000), # At the start of this phase remaining bots have 50 games
+    (92000, 2000), # end of starter bots, 60 games, 30 hours
+    (120000, 1000), # 100 games, 40 hours
+    (188000, 500), # 200 games, 2.5 days
+    (222000, 250), # 400 games, 3 days
+    (255000, 175), # 800 games, 3.5 days
+] # silver and up should have 3700+ games by end
+
 
 # Max number of games a bot version can error out in before being
 # stopped from playing
@@ -109,9 +137,6 @@ TIER_3_PERCENT = 1/64
 TIER_4_NAME = "Bronze"
 # What tier a player must be in to be eligible for GPUs
 GPU_TIER_NAME = TIER_2_NAME
-
-# What tier a player must be in to be eligible to participate in the finals
-FINALS_TIER_NAME = TIER_2_NAME
 
 TIER_0_STAY_BADGE = "A"
 TIER_1_STAY_BADGE = "B"

--- a/apiserver/apiserver/coordinator/coordinator.py
+++ b/apiserver/apiserver/coordinator/coordinator.py
@@ -425,9 +425,10 @@ def update_rankings(users):
     """
     users.sort(key=lambda user: user["rank"])
     # Set tau and draw_probability to more reasonable values than the defaults
-    # for the open competition. tau should be set to a much lower value or
-    # even 0 for finals
-    trueskill.setup(tau=0.008, draw_probability=0.001)
+    if config.COMPETITION_FINALS_PAIRING:
+        trueskill.setup(tau=0.0, draw_probability=0.001)
+    else:
+        trueskill.setup(tau=0.008, draw_probability=0.001)
     teams = [[trueskill.Rating(mu=user["mu"], sigma=user["sigma"])]
              for user in users]
     new_ratings = trueskill.rate(teams)

--- a/apiserver/apiserver/scripts/rating_reset.py
+++ b/apiserver/apiserver/scripts/rating_reset.py
@@ -1,0 +1,73 @@
+"""
+Reset all user ratings while saving current rating information by creating a
+new bot history entry.
+"""
+
+import argparse
+import sys
+
+import sqlalchemy
+
+from .. import model
+
+def main(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description="Reset user ratings.")
+    parser.add_argument("--execute", action="store_true")
+    cfg = parser.parse_args(args)
+
+    with model.engine.connect() as conn:
+        func = sqlalchemy.sql.func
+        transaction = conn.begin()
+        try:
+            total_ranked = model.total_ranked_users.alias("tr")
+            history_insert = model.bot_history.insert().from_select([
+                    model.bot_history.c.user_id,
+                    model.bot_history.c.bot_id,
+                    model.bot_history.c.version_number,
+                    model.bot_history.c.last_rank,
+                    model.bot_history.c.last_score,
+                    model.bot_history.c.last_num_players,
+                    model.bot_history.c.last_games_played,
+                    model.bot_history.c.language,
+                ],
+                sqlalchemy.sql.select([
+                        model.ranked_bots.c.user_id,
+                        model.ranked_bots.c.bot_id,
+                        model.ranked_bots.c.version_number,
+                        sqlalchemy.sql.text("ranked_bots.bot_rank"),
+                        model.ranked_bots.c.score,
+                        sqlalchemy.sql.text("total_ranked"),
+                        model.ranked_bots.c.games_played,
+                        model.ranked_bots.c.language,
+                ]).select_from(model.ranked_bots
+                ).select_from(model.total_ranked_users.alias("tr")
+                ).where(model.ranked_bots.c.games_played > 0)
+            )
+            bots_update = model.bots.update().values(
+                    version_number=model.bots.c.version_number + 1,
+                    games_played=0,
+                    mu=25,
+                    sigma=8.333,
+                    score=0,
+                )
+            insert_res = conn.execute(history_insert)
+            update_res = conn.execute(bots_update)
+            max_game_res = conn.execute(sqlalchemy.sql.select([
+                    func.max(model.games.c.id)]).select_from(model.games))
+            max_game = max_game_res.fetchone()[0]
+            print("%d bot history records inserted and %d ratings reset" % (
+                insert_res.rowcount, update_res.rowcount))
+            print("Reset at game id", max_game)
+        except:
+            transaction.rollback()
+            raise
+        else:
+            if cfg.execute:
+                transaction.commit()
+                print("Reset committed.")
+            else:
+                transaction.rollback()
+                print("Reset rolled back, use --execute to commit.")
+
+if __name__ == "__main__":
+    main()

--- a/apiserver/apiserver/scripts/rating_reset.py
+++ b/apiserver/apiserver/scripts/rating_reset.py
@@ -36,7 +36,7 @@ def main(args=sys.argv[1:]):
                         model.ranked_bots.c.version_number,
                         sqlalchemy.sql.text("ranked_bots.bot_rank"),
                         model.ranked_bots.c.score,
-                        sqlalchemy.sql.text("total_ranked"),
+                        sqlalchemy.sql.text("tr.*"),
                         model.ranked_bots.c.games_played,
                         model.ranked_bots.c.language,
                 ]).select_from(model.ranked_bots


### PR DESCRIPTION
This adds a few things for the finals to start with a full leaderboard reset and run with a progressive rank cutoff.

Main changes implemented are:
  * Adds a script to do a leaderboard reset by storing a new bot history entry with the current rating information and then resetting the rank, rating and games played information. This allows the final open competition rank and rating to be checked as the last retired entry in the bot history.
  * Set tau to 0 for finals as the composition of entries will be fixed.
  * Implements a method to set a schedule for the rank cutoff to automatically change as games are played in the finals.

I put example schedules for around 4000 and 5000 players in `config.py`. At current rates it looks like it will probably be around 3200 to 4200 players in the finals. As they get closer and the actual number of players can be predicted more accurately the schedule can be set accordingly. It's also pretty flexible on how large a proportion to give the top bots and where to set that final cutoff. The examples set the last cutoff for silver tier and above to get a few thousand games more than the next step down.

The example schedules also use a somewhat conservative 3000 games per hour where the actual rate has averaged around 3200 and they will probably run somewhat more than 6 full days.

Still on the to do list is a finals status page showing the current cutoff, number of games played in finals, cutoff schedule, and anything else that might be of interest.