### PR TITLE
Clean up install.sh script for halite executable

### DIFF
--- a/environment/install.sh
+++ b/environment/install.sh
@@ -1,10 +1,6 @@
-# Install Halite environment
-curl "https://halite.io/downloads/environment/HaliteEnvironment-Source.zip" -o "HaliteEnvironment-Source.zip"
-mkdir HaliteEnvironment-Source
-unzip HaliteEnvironment-Source.zip -d HaliteEnvironment-Source
-rm HaliteEnvironment-Source.zip
-cd HaliteEnvironment-Source
+#!/usr/bin/env bash
+
+set -e
+
+cmake .
 make
-mv halite ../
-cd ../
-rm -r HaliteEnvironment-Source 


### PR DESCRIPTION
Builds the `halite` executable. I did not check in `version.hpp` -- I'm guessing you'll want to release that, if you want to bump it.