### PR TITLE
Set drag to be much higher than max velocity

### DIFF
--- a/environment/core/Constants.hpp
+++ b/environment/core/Constants.hpp
@@ -21,7 +21,7 @@ namespace hlt {
         unsigned int EXTRA_PLANETS = 4;
         unsigned int MAX_TURNS = 300;
 
-        double DRAG = 7.0;
+        double DRAG = 10.0;
         double MAX_SPEED = 7.0;
         double MAX_ACCELERATION = 7.0;
 


### PR DESCRIPTION
There are still cases where a certain thrust command on some
platforms results in a velocity slightly higher than max due to
rounding; raising drag ensures these velocities end up as 0 at
the end of the turn regardless.

Fixes #114.