### PR TITLE
Move old game deletion to background to improve performance

### DIFF
--- a/apiserver/apiserver/scripts/delete_old_games.py
+++ b/apiserver/apiserver/scripts/delete_old_games.py
@@ -1,0 +1,56 @@
+import datetime
+import logging
+import sys
+
+import sqlalchemy
+
+from .. import config, model, util
+
+
+def delete_old_games():
+    """
+    Delete games older than 2 weeks for Bronze-tier players.
+    """
+    sqlfunc = sqlalchemy.sql.func
+    with model.engine.connect() as conn:
+        total_users = conn.execute(model.total_ranked_users).first()[0]
+        thresholds = util.tier_thresholds(total_users)
+
+        users = conn.execute(
+            sqlalchemy.sql.select([
+                model.ranked_bots_users.c.user_id,
+                model.ranked_bots_users.c.rank,
+            ]).where(
+                model.ranked_bots_users.c.rank >= thresholds[config.TIER_4_NAME]
+            )
+        ).fetchall()
+
+        for user in users:
+            logging.info("Clearing games for user {}".format(user["user_id"]))
+            with conn.begin():
+                cutoff_time = sqlfunc.adddate(sqlfunc.now(), -14)
+                # Delete all rows older than this in the various game tables
+                result = conn.execute(model.games.delete().where(
+                    sqlalchemy.sql.exists(
+                        model.game_participants.select().where(
+                            (model.game_participants.c.user_id == user["user_id"]) &
+                            (model.game_participants.c.game_id == model.games.c.id)
+                        )
+                    ) &
+                    (model.games.c.time_played < cutoff_time)
+                ))
+                logging.info("Deleted {} games".format(result.rowcount))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        handler = logging.handlers.RotatingFileHandler(
+            sys.argv[1],
+            maxBytes=1024*1024*20,
+            backupCount=20)
+        handler.setLevel(logging.DEBUG)
+        logging.getLogger("").addHandler(handler)
+
+    logging.info("Started job at {}".format(datetime.datetime.utcnow().isoformat()))
+
+    delete_old_games()

--- a/apiserver/delete_old_games.sh
+++ b/apiserver/delete_old_games.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd $(dirname $0)
+. venv/bin/activate
+
+export PYTHONPATH=$(pwd)
+
+python -m apiserver.scripts.delete_old_games "$(pwd)/delete_old_games.log"

--- a/apiserver/setup.sh
+++ b/apiserver/setup.sh
@@ -25,3 +25,7 @@ screen -S coordinator_internal -d -m /bin/bash -c \
 
 screen -S badge_daemon -d -m /bin/bash -c \
     "PYTHONPATH=$(pwd) python3 -m apiserver.scripts.badge_daemon.py"
+
+# Run game deletion job at 8 AM UTC = midnight PST (DOES NOT account
+# for DST)
+{ crontab -l -u worker; echo "0 8 * * * $(pwd)/delete_old_games.sh"; } | crontab -u worker -


### PR DESCRIPTION
With the number of users and games we have now, deleting old games is taking a significant amount of time. This causes queries to wait to lock the game table, which in turn causes workers to wait after uploading a game, slowing down our game rate.

This moves game deletion to a script run daily via cronjob at 8 AM UTC (midnight PST, not accounting for DST).