### PR TITLE
Fix compilation task race condition.

### DIFF
--- a/apiserver/apiserver/coordinator/compilation.py
+++ b/apiserver/apiserver/coordinator/compilation.py
@@ -29,6 +29,7 @@ def serve_compilation_task(conn):
         find_compilation_task = model.bots.select() \
             .where(model.bots.c.compile_status ==
                    model.CompileStatus.UPLOADED.value) \
+            .with_for_update() \
             .order_by(model.bots.c.user_id.asc()) \
             .limit(1)
         bot = conn.execute(find_compilation_task).first()


### PR DESCRIPTION
Fixes #382. This adds a for update clause to the select query when finding a bot to compile. This should prevent others from reading the compilation status as Uploaded before it has a chance to set it as InProgress.

I have tested this to the point that of checking that the function still works and hands out compilation tasks. But I didn't have a good way to check the race condition.