### PR TITLE
Convert the default Python Settler bot into Elixir

### DIFF
--- a/airesources/Elixir/README.md
+++ b/airesources/Elixir/README.md
@@ -10,7 +10,7 @@ by adding `elixirbot` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:elixirbot, "~> 0.1.0"}
+    {:elixirbot, "~> 0.2.0"}
   ]
 end
 ```

--- a/airesources/Elixir/lib/elixirbot.ex
+++ b/airesources/Elixir/lib/elixirbot.ex
@@ -1,2 +1,53 @@
 defmodule Elixirbot do
+  def make_move(map) do
+    player = GameMap.get_me(map)
+    Enum.map(flying_ships(Player.all_ships(player)), fn(ship) ->
+      make_move_for_ship(map, ship)
+    end)
+  end
+
+  def make_move_for_ship(map, ship) do
+    # For each planet in the game that doesn't have an owner (only non-destroyed planets are included)
+    Enum.find_value(unowned_planets(GameMap.all_planets(map)), fn(planet) ->
+      if command = try_to_dock(%{ ship: ship, planet: planet }) do
+        # If we can dock, let's (try to) dock. If two ships try to dock at once, neither will be able to.
+        command
+      else
+        # If we can't dock, we move towards the closest empty point near this planet (by using closest_point_to)
+        # with constant speed. Don't worry about pathfinding for now, as the command will do it for you.
+        # We run this navigate command each turn until we arrive to get the latest move.
+        # Here we move at half our maximum speed to better control the ships
+        # In order to execute faster we also choose to ignore ship collision calculations during navigation.
+        # This will mean that you have a higher probability of crashing into ships, but it also means you will
+        # make move decisions much quicker. As your skill progresses and your moves turn more optimal you may
+        # wish to turn that option off.
+        #
+        # If a move is possible, return it so it can be added to the command_queue (if there are too many obstacles on the way
+        # or we are trapped (or we reached our destination!), navigate_command will return null;
+        # don't fret though, we can run the command again the next turn)
+        Ship.navigate(
+          ship,
+          Position.closest_point_to(ship, planet),
+          map,
+          :math.floor(GameConstants.max_speed / 2.0),
+          [ignore_ships: true]
+        )
+      end
+    end)
+  end
+
+  def unowned_planets(planets) do
+    Enum.reject(planets, &Planet.is_owned?/1)
+  end
+
+  def flying_ships(ships) do
+    Enum.filter(ships, fn(ship) ->
+      ship.docking_status == DockingStatus.undocked
+    end)
+  end
+
+  # Return a dock command if we can dock
+  def try_to_dock(%{ship: ship, planet: planet}) do
+    if Ship.can_dock?(ship, planet), do: Ship.dock(%{ship: ship, planet: planet}), else: nil
+  end
 end

--- a/airesources/Elixir/lib/elixirbot/cli.ex
+++ b/airesources/Elixir/lib/elixirbot/cli.ex
@@ -1,6 +1,6 @@
 defmodule Elixirbot.CLI do
-  def main(args \\ []) do
+  def main(_ \\ []) do
     Elixirbot.Game.connect("Alchemist")
-      |> Elixirbot.Game.update_map
+      |> Elixirbot.Game.run
   end
 end

--- a/airesources/Elixir/lib/elixirbot/docking_status.ex
+++ b/airesources/Elixir/lib/elixirbot/docking_status.ex
@@ -1,0 +1,7 @@
+defmodule DockingStatus do
+  def undocked,  do: 0
+  def docking,   do: 1
+  def docked,    do: 2
+  def undocking, do: 3
+  def all,       do: [undocked(), docking(), docked(), undocking()]
+end

--- a/airesources/Elixir/lib/elixirbot/game.ex
+++ b/airesources/Elixir/lib/elixirbot/game.ex
@@ -1,194 +1,65 @@
 defmodule Elixirbot.Game do
   require Logger
   require Map
-
-  defmodule GameMap do
-    defstruct player_id: nil, width: nil, height: nil
-  end
-
-  defmodule Player do
-    defstruct player_id: nil, ships: []
-  end
-
-  defmodule Ship do
-    defstruct id: nil, owner: nil, x: nil, y: nil, radius: nil, health: nil, docking_status: nil, docking_progress: nil, planet: nil
-  end
-
-  defmodule Planet do
-    defstruct id: nil, owner: nil, x: nil, y: nil, radius: nil, health: nil, docking_spots: nil, docked_ship_ids: nil, docked_ships: nil
-  end
+  require Planet
+  require Player
+  require Ship
+  require GameMap
+  import Elixirbot.Util
 
   def connect(name) do
     player_id = read_from_input()
     set_up_logging(name, player_id)
-    [width, height] = read_ints_from_input
+    [width, height] = read_ints_from_input()
     Logger.info "game size: #{width} x #{height}"
+    Logger.info "initializing bot #{inspect(name)}"
     write_to_output(name)
-    {players, planets} = fetch_map_state
-    map = %GameMap{player_id: parse_int(player_id), width: width, height: height}
-    prepare_game(map, players, planets)
-    map
+    %GameMap{my_id: parse_int(player_id), width: width, height: height}
+      |> update_map
   end
 
-  def prepare_game(map, players, planets) do
-    # We now have 1 full minute to analyse the initial map.
-    make_move(map, players, planets)
-      |> Enum.join(" ")
-      |> write_to_output
+  def update_map(map) do
+    GameMap.update(map, input_tokens())
+  end
+
+  defp input_tokens() do
+    read_from_input() |> String.split(" ")
   end
 
   defp read_from_input() do
-    input_line = IO.gets("") |> String.strip
-    Logger.debug "received: #{input_line}"
-    input_line
+    IO.gets("") |> String.trim
   end
 
   defp set_up_logging(name, player_id) do
     Logger.add_backend {LoggerFileBackend, :debug}
     Logger.configure_backend {LoggerFileBackend, :debug}, path: "#{player_id}_#{name}.log"
     Logger.info "Starting new game for #{name}:#{player_id}"
-    Logger.info "Setting up logger"
   end
 
   def read_ints_from_input do
     read_from_input()
       |> String.split(" ")
-      |> Enum.map(fn(x) -> parse_int(x) end)
+      |> Enum.map(&parse_int/1)
   end
 
   defp write_to_output(message) do
-    message = "#{String.strip(message)}\n"
-    Logger.info("Sending: #{message}")
-    IO.puts(message)
+    String.trim(message)
+      |> IO.puts
   end
 
-  def fetch_map_state do
-    tokens = read_from_input() |> String.split(" ")
-    {tokens, players} = read_from_input() |> String.split(" ") |> parse_players
-    {[], planets} = tokens |> parse_planets
-    {players, planets}
-  end
-
-  def update_map(map) do
-    {players, planets} = fetch_map_state
-    make_move(map, players, planets)
+  def send_command_queue(commands) do
+    commands
       |> Enum.join(" ")
       |> write_to_output
-    update_map(map)
   end
 
-  def make_move(map, players, planets) do
-    Logger.info("finding player #{map.player_id}")
-    player = Enum.find(players, fn(player) -> Logger.info("finding player #{inspect(player)}, #{inspect(player.player_id)} == #{inspect(map.player_id)} = #{player.player_id == map.player_id}"); player.player_id == map.player_id end)
-    Logger.info("found player #{inspect(player)}")
-    opponent_ships = Enum.flat_map(players, fn(player) -> if (player.player_id == map.player_id), do: [], else: player.ships end)
-    Enum.map(player.ships, fn(ship) -> make_move_for_ship(ship, opponent_ships, planets) end)
-  end
+  def run(map, turn_num \\ 0) do
+    Logger.info("---- Turn #{turn_num} ----")
+    map
+      |> update_map
+      |> Elixirbot.make_move
+      |> send_command_queue
 
-  def make_move_for_ship(ship, opponent_ships, planets) do
-    Logger.info("making move for ship: #{inspect(ship)}")
-    "t #{ship.id} #{Enum.random(1..7)} #{Enum.random(0..359)}"
-  end
-
-  def parse_players(tokens) do
-    [count_of_players|tokens] = tokens
-    Logger.info "Parsing #{count_of_players} players"
-
-    {players, tokens} = parse_players(parse_int(count_of_players), tokens)
-
-    Logger.debug "Parsed players: #{inspect(players)}"
-    {tokens, players}
-  end
-
-  def parse_players(0, tokens), do: {[], tokens}
-  def parse_players(count_of_players, tokens) do
-    [player_id|tokens] = tokens
-    player_id = parse_int(player_id)
-    {ships, tokens} = parse_ships(player_id, tokens)
-
-    player = %Player{player_id: player_id, ships: ships}
-    Logger.debug "Parsed player: #{inspect(player)}"
-
-    {players, tokens} = parse_players(count_of_players-1, tokens)
-    {players++[player], tokens}
-  end
-
-  def parse_ships(player_id, tokens) do
-    [count_of_ships|tokens] = tokens
-
-    {ships, tokens} = parse_ships(parse_int(count_of_ships), player_id, tokens)
-    Logger.debug "Parsed ships: #{inspect(ships)}"
-
-    {ships, tokens}
-  end
-
-  def parse_ships(0, _, tokens), do: {[], tokens}
-  def parse_ships(count_of_ships, player_id, tokens) do
-    [id, x, y, hp, _, _, status, planet, progress, _|tokens] = tokens
-    id = parse_int(id)
-
-    ship = %Ship{id: id,
-                 owner: player_id,
-                 x: parse_float(x),
-                 y: parse_float(y),
-                 radius: nil,
-                 health: parse_int(hp),
-                 docking_status: parse_int(status),
-                 docking_progress: parse_int(progress),
-                 planet: parse_int(planet)}
-    Logger.debug "Parsed ship: #{inspect(ship)}"
-
-    {ships, tokens} = parse_ships(count_of_ships-1, player_id, tokens)
-    {ships++[ship], tokens}
-  end
-
-  def parse_planets(tokens) do
-    [count_of_planets|tokens] = tokens
-    planets = %{}
-
-    {planets, tokens} = parse_planets(parse_int(count_of_planets), tokens)
-
-    Logger.debug "Parsed planets: #{inspect(planets)}"
-    {tokens, planets}
-  end
-
-  def parse_planets(0, tokens), do: {%{}, tokens}
-  def parse_planets(count_of_planets, tokens) do
-    [id, x, y, hp, r, docking_spots, _, _, is_owned, owner, ship_count|tokens] = tokens
-    id = parse_int(id)
-    owner = parse_int(owner)
-
-    # Fetch the ship ids from the tokens array
-    docked_ships = parse_docked_ships(parse_int(ship_count), tokens)
-
-    planet = %Planet{id: id,
-                     x: parse_float(x),
-                     y: parse_float(y),
-                     health: parse_int(hp),
-                     radius: parse_float(r),
-                     docking_spots: parse_int(docking_spots),
-                     owner: owner,
-                     docked_ships: docked_ships}
-    Logger.debug "Parsed planet: #{inspect(planet)}"
-
-    {planets, tokens} = parse_planets(count_of_planets-1, tokens)
-    {Map.merge(%{id => planet}, planets), tokens}
-  end
-
-  defp parse_docked_ships(0, tokens), do: {[], tokens}
-  defp parse_docked_ships(ship_count, tokens) do
-    [ship|tokens] = tokens
-    {ships, tokens} = parse_docked_ships(ship_count-1, tokens)
-    {ships++[ship], tokens}
-  end
-
-  defp parse_int(nil), do: nil
-  defp parse_int(str) do
-    str |> String.to_integer
-  end
-
-  defp parse_float(nil), do: nil
-  defp parse_float(str) do
-    str |> String.to_float
+    run(map, turn_num + 1)
   end
 end

--- a/airesources/Elixir/lib/elixirbot/game_constants.ex
+++ b/airesources/Elixir/lib/elixirbot/game_constants.ex
@@ -1,0 +1,26 @@
+defmodule GameConstants do
+  #: Max number of units of distance a ship can travel in a turn
+  def max_speed, do: 7
+  #: Radius of a ship
+  def ship_radius, do: 0.5
+  #: Starting health of ship, also its max
+  def max_ship_health, do: 255
+  #: Starting health of ship, also its max
+  def base_ship_health, do: 255
+  #: Weapon cooldown period
+  def weapon_cooldown, do: 1
+  #: Weapon damage radius
+  def weapon_radius, do: 5.0
+  #: Weapon damage
+  def weapon_damage, do: 64
+  #: Radius in which explosions affect other entities
+  def explosion_radius, do: 10.0
+  #: Distance from the edge of the planet at which ships can try to dock
+  def dock_radius, do: 4.0
+  #: Number of turns it takes to dock a ship
+  def dock_turns, do: 5
+  #: Number of production units per turn contributed by each docked ship
+  def base_productivity, do: 6
+  #: Distance from the planets edge at which new ships are created
+  def spawn_radius, do: 2.0
+end

--- a/airesources/Elixir/lib/elixirbot/game_map.ex
+++ b/airesources/Elixir/lib/elixirbot/game_map.ex
@@ -1,0 +1,67 @@
+defmodule GameMap do
+  defstruct my_id: nil, width: nil, height: nil, players: [], planets: []
+
+  # The user's player
+  def get_me(map) do
+    get_player(map, map.my_id)
+  end
+
+  # player_id: The id of the desired player
+  # The player associated with player_id
+  def get_player(map, player_id) do
+    Enum.find(all_players(map), &(&1.player_id == player_id))
+  end
+
+  # List of all players
+  def all_players(map) do
+    map.players
+  end
+
+  # The planet associated with planet_id
+  def get_planet(map, planet_id) do
+    Enum.find(map.planets, &(&1.id == planet_id))
+  end
+
+  # List of all planets
+  def all_planets(map) do
+    Enum.map(map.planets, fn({_, planet}) ->
+      planet
+    end)
+  end
+
+  def all_entities(map) do
+    all_planets(map) ++ all_ships(map)
+  end
+
+  def all_ships(map) do
+    Enum.map(all_players(map), &Player.all_ships/1)
+      |> List.flatten
+  end
+
+  def update(map, tokens) do
+    {tokens, players} = tokens |> Player.parse
+    {[], planets}     = tokens |> Planet.parse(all_ships(map))
+    with_entities(map, {players, planets})
+  end
+
+  def with_entities(map, { players, planets }) do
+    Map.merge(map, %{players: players, planets: planets})
+  end
+
+  # entity: The source entity to find distances from
+  #
+  # Returns a map of distances with the values being lists of entities at that distance
+  def nearby_entities_by_distance(map, entity) do
+    Enum.reduce(all_entities_except(all_entities(map), entity), %{}, fn(foreign_entity, acc) ->
+      distance = Position.calculate_distance_between(entity, foreign_entity)
+      Map.put_new(acc, distance, [])
+      Map.put(acc, distance, acc[distance] ++ [foreign_entity])
+    end)
+  end
+
+  def all_entities_except(entities, entity) do
+    Enum.reject(entities, fn(other) ->
+      entity == other
+    end)
+  end
+end

--- a/airesources/Elixir/lib/elixirbot/planet.ex
+++ b/airesources/Elixir/lib/elixirbot/planet.ex
@@ -1,0 +1,72 @@
+# A planet on the game map.
+#
+# id: The planet ID.
+# x: The planet x-coordinate.
+# y: The planet y-coordinate.
+# radius: The planet radius.
+# num_docking_spots: The max number of ships that can be docked.
+# health: The planet's health.
+# owner: The player ID of the owner, if any. If nil, Entity is not owned.
+defmodule Planet do
+  import Elixirbot.Util
+
+  defstruct id: nil, owner: nil, x: nil, y: nil, radius: nil, health: nil, num_docking_spots: nil, docked_ships: nil
+
+  def get_docked_ship(planet, id) do
+    Enum.find(all_docked_ships(planet), fn(ship) ->
+      ship.id == id
+    end)
+  end
+
+  def all_docked_ships(planet) do
+    { ships, _ } = planet.docked_ships
+    ships
+  end
+
+  def is_owned?(planet) do
+    planet.owner != nil
+  end
+
+  def is_full?(planet) do
+    length(all_docked_ships(planet)) >= planet.num_docking_spots
+  end
+
+  def parse(tokens, ships) do
+    [count_of_planets|tokens] = tokens
+
+    {planets, tokens} = parse(parse_int(count_of_planets), tokens, ships)
+
+    {tokens, planets}
+  end
+
+  def parse(0, tokens, _), do: {%{}, tokens}
+  def parse(count_of_planets, tokens, ships) do
+    [id, x, y, hp, r, docking_spots, _, _, owned, owner, ship_count|tokens] = tokens
+
+    # Fetch the ship ids from the tokens array
+    {docked_ship_ids, tokens} = parse_docked_ship_ids(parse_int(ship_count), tokens)
+
+    planet = %Planet{
+      id:                parse_int(id),
+      x:                 parse_float(x),
+      y:                 parse_float(y),
+      health:            parse_int(hp),
+      radius:            parse_float(r),
+      num_docking_spots: parse_int(docking_spots),
+      owner:             if(parse_int(owned) == 0, do: nil, else: parse_int(owner)),
+      docked_ships:      Enum.map(docked_ship_ids, fn(ship_id) ->
+        Ship.get(ships, ship_id)
+      end)
+    }
+
+    {planets, tokens} = parse(count_of_planets - 1, tokens, ships)
+    {Map.merge(%{id => planet}, planets), tokens}
+  end
+
+  defp parse_docked_ship_ids(0, tokens), do: {[], tokens}
+  defp parse_docked_ship_ids(ship_count, tokens) do
+    [ship_id|tokens] = tokens
+    {ship_ids, tokens} = parse_docked_ship_ids(ship_count - 1, tokens)
+    {ship_ids++[ship_id], tokens}
+  end
+end

--- a/airesources/Elixir/lib/elixirbot/player.ex
+++ b/airesources/Elixir/lib/elixirbot/player.ex
@@ -1,0 +1,33 @@
+defmodule Player do
+  import Elixirbot.Util
+
+  defstruct player_id: nil, ships: []
+
+  def all_ships(player) do
+    player.ships
+  end
+
+  def get_ship(player, ship_id) do
+    Ship.get(all_ships(player), ship_id)
+  end
+
+  def parse(tokens) do
+    [count_of_players|tokens] = tokens
+
+    {players, tokens} = parse(parse_int(count_of_players), tokens)
+
+    {tokens, players}
+  end
+
+  def parse(0, tokens), do: {[], tokens}
+  def parse(count_of_players, tokens) do
+    [player_id|tokens] = tokens
+    player_id = parse_int(player_id)
+    {ships, tokens} = Ship.parse(player_id, tokens)
+
+    player = %Player{player_id: player_id, ships: ships}
+
+    {players, tokens} = parse(count_of_players - 1, tokens)
+    {players++[player], tokens}
+  end
+end

--- a/airesources/Elixir/lib/elixirbot/position.ex
+++ b/airesources/Elixir/lib/elixirbot/position.ex
@@ -1,0 +1,98 @@
+defmodule Position do
+  import Elixirbot.Util
+
+  defstruct x: 0.0, y: 0.0, radius: 0.0
+
+  def calculate_distance_between(%{ x: origin_x, y: origin_y }, %{ x: target_x, y: target_y }) do
+    :math.sqrt(:math.pow(origin_x - target_x, 2) + :math.pow(origin_y - target_y, 2))
+  end
+
+  def calculate_deg_angle_between(origin, target) do
+    calculate_angle_between(origin, target)
+      |> angle_rad_to_deg_clipped
+  end
+
+  def calculate_angle_between(%{ x: origin_x, y: origin_y }, %{ x: target_x, y: target_y }) do
+    :math.atan2(target_y - origin_y, target_x - origin_x)
+  end
+
+  # Find the closest point to the given ship near the given target, outside its given radius,
+  # with an added fudge of min_distance.
+  #
+  # target: The target to compare against
+  # min_distance: Minimum distance specified from the object's outer radius
+  # Returns the closest point's coordinates
+  def closest_point_to(origin, %{ x: target_x, y: target_y, radius: target_radius } = target, min_distance \\ 3) do
+    angle = calculate_angle_between(origin, target)
+    radius = target_radius + min_distance
+    x = target_x + radius * :math.cos(angle)
+    y = target_y + radius * :math.sin(angle)
+
+    %Position{ x: x, y: y }
+  end
+
+  def to_radians(angle) do
+    angle / :math.pi * 180.0
+  end
+
+  # Check whether there is a straight-line path to the given point, without planetary obstacles in between.
+
+  # ship: Source entity
+  # target: Target entity
+  # ignore: Which entity type(s) to ignore
+  #
+  # Returns the list of obstacles between the ship and target
+  def obstacles_between(map, origin, target, ignore \\ []) do
+    entities = []
+    entities = if Enum.find_index(ignore, &(&1 == :planets)), do: entities, else: entities ++ GameMap.all_planets(map)
+    entities = if Enum.find_index(ignore, &(&1 == :ships)),   do: entities, else:  entities ++ GameMap.all_ships(map)
+
+    obstacles = entities
+      |> GameMap.all_entities_except(origin)
+      |> GameMap.all_entities_except(target)
+    result = Enum.filter(obstacles, fn(entity) ->
+      intersect_segment_circle(origin, target, entity, origin.radius + 0.1)
+    end)
+
+    result
+  end
+
+  # Test whether a line segment and circle intersect.
+
+  # start: The start of the line segment. (Needs x, y attributes)
+  # end: The end of the line segment. (Needs x, y attributes)
+  # circle: The circle to test against. (Needs x, y, r attributes)
+  # fudge: A fudge factor; additional distance to leave between the segment and circle. (Probably set this to the ship radius, 0.5.)
+  # Returns if intersects or not
+  def intersect_segment_circle(start, end_point, circle, fudge \\ GameConstants.ship_radius) do
+    # Derived with SymPy
+    # Parameterize the segment as start + t * (end_point - start),
+    # and substitute into the equation of a circle
+    # Solve for t
+    dx = end_point.x - start.x
+    dy = end_point.y - start.y
+
+    a = dx * dx + dy * dy
+    # When a == 0.0, start and end_point are the same point
+    if a == 0.0 do
+      calculate_distance_between(start, circle) <= circle.radius + fudge
+    else
+      b = -2 * (
+        start.x * start.x - start.x * end_point.x - start.x * circle.x + end_point.x * circle.x +
+        start.y * start.y - start.y * end_point.y - start.y * circle.y + end_point.y * circle.y
+      )
+
+      # Time along segment when closest to the circle (vertex of the quadratic)
+      t = Enum.min([-b / (2 * a), 1.0])
+      if t < 0 do
+        false
+      else
+        closest_x = start.x + dx * t
+        closest_y = start.y + dy * t
+        closest_distance = Position.calculate_distance_between(%Position{ x: closest_x, y: closest_y }, circle)
+
+        closest_distance <= circle.radius + fudge
+      end
+    end
+  end
+end

--- a/airesources/Elixir/lib/elixirbot/ship.ex
+++ b/airesources/Elixir/lib/elixirbot/ship.ex
@@ -1,0 +1,146 @@
+# A ship in the game.
+#
+# id: The ship ID.
+# x: The ship x-coordinate.
+# y: The ship y-coordinate.
+# radius: The ship radius.
+# health: The ship's remaining health.
+# docking_status: The docking status (UNDOCKED, DOCKED, DOCKING, UNDOCKING)
+# docking_progres: How many turns the ship has been docking/undocking
+# planet: The ID of the planet the ship is docked to, if applicable.
+# owner: The player ID of the owner, if any. If nil, Entity is not owned.
+defmodule Ship do
+  import Elixirbot.Util
+
+  defstruct id: nil, owner: nil, x: nil, y: nil, radius: GameConstants.ship_radius, health: nil, docking_status: nil, docking_progress: nil, planet: nil
+
+  defmodule ThrustCommand do
+    defstruct ship: nil, magnitude: nil, angle: nil
+  end
+  defmodule DockCommand do
+    defstruct ship: nil, planet: nil
+  end
+  defmodule UndockCommand do
+    defstruct ship: nil
+  end
+
+  def get(ships, ship_id) do
+    Enum.find(ships, fn(ship) ->
+      ship.id == ship_id
+    end)
+  end
+
+  # Determine whether a ship can dock to a planet
+  #
+  # planet: The planet wherein you wish to dock
+  # Returns whether a ship can dock or not
+  def can_dock?(ship, planet) do
+    Position.calculate_distance_between(ship, planet) <= planet.radius + GameConstants.dock_radius + GameConstants.ship_radius
+  end
+
+  # Generate a command to accelerate this ship.
+
+  # :param int magnitude: The speed through which to move the ship
+  # :param int angle: The angle to move the ship in
+  # :return: The command string to be passed to the Halite engine.
+  def thrust(%ThrustCommand{ ship: ship, magnitude: magnitude, angle: angle}) do
+    # we want to round angle to nearest integer, but we want to round
+    # magnitude down to prevent overshooting and unintended collisions
+    "t #{ship.id} #{round(:math.floor(magnitude))} #{round(angle)}"
+  end
+
+  # Generate a command to dock to a planet.
+
+  # :param Planet planet: The planet object to dock to
+  # :return: The command string to be passed to the Halite engine.
+  def dock(%{ ship: ship, planet: planet }) do
+    "d #{ship.id} #{planet.id}"
+  end
+
+  # Generate a command to undock from the current planet.
+
+  # :return: The command trying to be passed to the Halite engine.
+  def undock(%UndockCommand{ ship: ship }) do
+    "u #{ship.id}"
+  end
+
+  # Move a ship to a specific target position (Entity). It is recommended to place the position
+  # itself here, else navigate will crash into the target. If avoid_obstacles is set to True (default)
+  # will avoid obstacles on the way, with up to max_corrections corrections. Note that each correction accounts
+  # for angular_step degrees difference, meaning that the algorithm will naively try max_correction degrees before giving
+  # up (and returning nil). The navigation will only consist of up to one command; call this method again
+  # in the next turn to continue navigating to the position.
+
+  # target: The entity to which you will navigate
+  # game_map: The map of the game, from which obstacles will be extracted
+  # speed: The (max) speed to navigate. If the obstacle is nearer, will adjust accordingly.
+  # avoid_obstacles: Whether to avoid the obstacles in the way (simple pathfinding).
+  # max_corrections: The maximum number of degrees to deviate per turn while trying to pathfind. If exceeded returns nil.
+  # angular_step: The degree difference to deviate if the original destination has obstacles
+  # ignore_ships: Whether to ignore ships in calculations (this will make your movement faster, but more precarious)
+  # ignore_planets: Whether to ignore planets in calculations (useful if you want to crash onto planets)
+  #
+  # Return the command trying to be passed to the Halite engine or nil if movement is not possible within max_corrections degrees.
+  def navigate(ship, target, map, speed, options \\ []) do
+    # Default options
+    defaults = [avoid_obstacles: true, max_corrections: 90, angular_step: 1, ignore_ships: false, ignore_planets: false]
+    %{ avoid_obstacles: avoid_obstacles, max_corrections: max_corrections, angular_step: angular_step, ignore_ships: ignore_ships, ignore_planets: ignore_planets } = Keyword.merge(defaults, options) |> Enum.into(%{})
+
+    navigate(ship, target, map, speed, avoid_obstacles, max_corrections, angular_step, ignore_ships, ignore_planets)
+  end
+
+  def navigate(   _,      _,   _,     _,               _,               0,            _,            _,              _), do: nil
+  def navigate(ship, target, map, speed, avoid_obstacles, max_corrections, angular_step, ignore_ships, ignore_planets) do
+    distance = Position.calculate_distance_between(ship, target)
+    angle    = Position.calculate_deg_angle_between(ship, target)
+
+    ignore = []
+    ignore = if(ignore_ships,   do: ignore ++ [:ships],   else: ignore)
+    ignore = if(ignore_planets, do: ignore ++ [:planets], else: ignore)
+
+    if avoid_obstacles && length(Position.obstacles_between(map, ship, target, ignore)) > 0 do
+      delta_radians = (angle + angular_step) / 180.0 * :math.pi
+      new_target_dx = :math.cos(delta_radians) * distance
+      new_target_dy = :math.sin(delta_radians) * distance
+      new_target    = %Position{ x: ship.x + new_target_dx, y: ship.y + new_target_dy }
+      nav_options   = [
+        avoid_obstacles: avoid_obstacles,
+        max_corrections: max_corrections - 1,
+        angular_step:    angular_step,
+        ignore_ships:    ignore_ships,
+        ignore_planets:  ignore_planets
+      ]
+      navigate(ship, new_target, map, speed, nav_options)
+    else
+      safe_speed = Enum.min([distance, speed])
+      thrust(%ThrustCommand{ ship: ship, magnitude: safe_speed, angle: angle })
+    end
+  end
+
+  def parse(player_id, tokens) do
+    [count_of_ships|tokens] = tokens
+
+    {ships, tokens} = parse(parse_int(count_of_ships), player_id, tokens)
+
+    {ships, tokens}
+  end
+
+  def parse(0, _, tokens), do: {[], tokens}
+  def parse(count_of_ships, player_id, tokens) do
+    [id, x, y, hp, _, _, status, planet, progress, _|tokens] = tokens
+
+    ship = %Ship{
+      id:               parse_int(id),
+      owner:            player_id,
+      x:                parse_float(x),
+      y:                parse_float(y),
+      health:           parse_int(hp),
+      docking_status:   parse_int(status),
+      docking_progress: parse_int(progress),
+      planet:           parse_int(planet)
+    }
+
+    {ships, tokens} = parse(count_of_ships - 1, player_id, tokens)
+    {ships++[ship], tokens}
+  end
+end

--- a/airesources/Elixir/lib/elixirbot/util.ex
+++ b/airesources/Elixir/lib/elixirbot/util.ex
@@ -22,6 +22,16 @@ defmodule Elixirbot.Util do
       156
   """
   def angle_rad_to_deg_clipped(angle_rad) do
-    degUnclipped = (angle_rad_to_deg(angle_rad) |> round |> rem(360)) + 360 |> rem(360)
+    (angle_rad_to_deg(angle_rad) |> round |> rem(360)) + 360 |> rem(360)
+  end
+
+  def parse_int(nil), do: nil
+  def parse_int(str) do
+    str |> String.to_integer
+  end
+
+  def parse_float(nil), do: nil
+  def parse_float(str) do
+    str |> String.to_float
   end
 end

--- a/airesources/Elixir/mix.exs
+++ b/airesources/Elixir/mix.exs
@@ -4,7 +4,7 @@ defmodule Elixirbot.Mixfile do
   def project do
     [
       app: :elixirbot,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
       escript: [main_module: Elixirbot.CLI, path: 'MyBot'],


### PR DESCRIPTION
For the most part, try to keep the same logic and concepts that are in the Python Settler bot, but make it a little more 'functional'.

Also moved entities into their own files and moved parsing responsibility into each entity's file.