### PR TITLE
Add background colors to identify old version and challenge games.

### DIFF
--- a/website/_sass/_user-profile.scss
+++ b/website/_sass/_user-profile.scss
@@ -206,6 +206,15 @@
     tbody > tr > td {
       background-color: #000;
     }
+    tbody > tr > td.old-bot-odd{
+      background-color: #211f2e;
+    }
+    tbody > tr > td.old-bot-even{
+      background-color: #282538;
+    }
+    tbody > tr > td.challenge{
+      background-color: #1c1c13;
+    }
     .winner {
       color: #20A257;
     }

--- a/website/javascript/templates/UserProfile.vue
+++ b/website/javascript/templates/UserProfile.vue
@@ -169,12 +169,12 @@
                                         </thead>
                                         <tbody>
                                             <tr v-for="game in games">
-                                                <td>
+                                                <td v-bind:class="game.versions_back ? (game.versions_back % 2 ? 'old-bot-odd' : 'old-bot-even') : ''">
                                                     <a :href="'/play?game_id=' + game.game_id">
                                                         {{getFormattedDateForGames(game.time_played)}}
                                                     </a>
                                                 </td>
-                                                <td>
+                                                <td v-bind:class="{ 'challenge': game.challenge_id }">
                                                     <div class="info-icon-trophy" v-if="game.players[user.user_id].rank === 1">
                                                         <span class="icon-trophy"></span>
                                                     </div>
@@ -633,6 +633,10 @@
 
                         this.profile_images[player_id] = api.make_profile_image_url(username)
                         this.usernames[player_id] = username
+
+                        if (player_id == this.user.user_id) {
+                            game.versions_back = this.user.num_submissions - player.version_number
+                        }
                       }
 
                       const players = Object.values(game.players).sort((r1, r2) => {


### PR DESCRIPTION
This adds some background color changes on the user profile game list to distinguish games played by old bot versions and games played in challenges.

Old bot versions change the background of the "Watch" column, alternating between two shades. Here's a screenshot going from the current version to the previous version:
![image](https://user-images.githubusercontent.com/392930/34396466-417f8b32-eb39-11e7-9aba-0c2a8d1bbbf0.png)

And changes the background of the "Result" column in challenge games.
![image](https://user-images.githubusercontent.com/392930/34396479-64c8a376-eb39-11e7-81ea-07cece1bdc34.png)
