### PR TITLE
Set last match time for challenges to prevent getting stuck

### DIFF
--- a/apiserver/apiserver/coordinator/matchmaking.py
+++ b/apiserver/apiserver/coordinator/matchmaking.py
@@ -224,6 +224,12 @@ def find_challenge(conn, has_gpu=False):
         user_bots[bot["user_id"]].append(bot)
 
     if len(user_bots) < 2 or challenge["issuer"] not in user_bots:
+        # We had to skip this challenge, but give it a time anyways,
+        # so that we don't get stuck on it
+        conn.execute(model.challenges.update().values(
+            most_recent_game_task=sqlalchemy.sql.func.now(),
+        ).where(model.challenges.c.id == challenge["id"]))
+
         return None
 
     selected_bots = [random.choice(user_bots[challenge["issuer"]])]


### PR DESCRIPTION
If a challenge game could not be played for some reason (e.g. one of
the participants has no bots), this would stop all challenge games,
because the matchmaker would keep trying to issue games for the same
challenge.  This changes it so that even if a game could not be
played, the most recent match time is still updated, so that we
don't get stuck on that challenge.