### PR TITLE
Fix documentation for Planet.owner.

### DIFF
--- a/airesources/Python3/hlt/entity.py
+++ b/airesources/Python3/hlt/entity.py
@@ -89,7 +89,7 @@ class Planet(Entity):
     :ivar current_production: How much production the planet has generated at the moment. Once it reaches the threshold, a ship will spawn and this will be reset.
     :ivar remaining_resources: The remaining production capacity of the planet.
     :ivar health: The planet's health.
-    :ivar owner: The player ID of the owner, if any. If None, Entity is not owned.
+    :ivar owner: The Player object of the owner, if any. Else None if Planet is not owned.
 
     """
 


### PR DESCRIPTION
Planet.owner is never a player id to user visible code, it's changed from an id to a Player object before game.update_map() returns after parsing the game state.