### PR TITLE
Increase leaderboard api query limit.

### DIFF
--- a/apiserver/apiserver/web/leaderboard.py
+++ b/apiserver/apiserver/web/leaderboard.py
@@ -32,7 +32,7 @@ def _count_leaderboard_query(where_clause):
 def leaderboard():
     result = []
     offset, limit = api_util.get_offset_limit(default_limit=250,
-                                              max_limit=5000)
+                                              max_limit=10000)
 
     where_clause, order_clause, manual_sort = api_util.get_sort_filter({
         "user_id": model.ranked_bots_users.c.user_id,


### PR DESCRIPTION
This keeps the leaderboard from breaking when the number of users exceeds 5000. It appears that all the api calls that would be affected in javascript are already using a limit of either 99,999 or 999,999 so they should be fine.

This isn't really the best fix but should work fine, or at least no more than incrementally worse than it currently does. The best fix would probably be to make the leaderboards load truly incrementally. But that requires adding some api endpoints to serve the information needed to populate the leaderboard filters (e.g. the full list of players, organizations, etc.).