### PR TITLE
Status page for finals.

### DIFF
--- a/website/finals-status.md
+++ b/website/finals-status.md
@@ -1,0 +1,15 @@
+---
+layout: page
+toc: false
+full_width: true
+mount_view: FinalsStatus
+permalink: /finals-status
+title: Halite Finals
+image: assets/images/opengraph.png
+content: website
+description: Current status of Halite 2 finals.
+---
+
+<div id="finals-status">
+
+</div>

--- a/website/javascript/main.js
+++ b/website/javascript/main.js
@@ -5,6 +5,7 @@ import 'url-search-params-polyfill'
 import 'element-ui/lib/theme-default/index.css'
 import Associate from './templates/Associate.vue'
 import BotEditor from './templates/BotEditor.vue'
+import FinalsStatus from './templates/FinalsStatus.vue'
 import GameFeed from './templates/GameFeed.vue'
 import HackathonLeaderboard from './templates/HackathonLeaderboard.vue'
 import LeaderboardContainer from './templates/LeaderboardContainer.vue'
@@ -44,6 +45,12 @@ window.views = {
     new Vue({
       el: '#bot-editor-container',
       render: (h) => h(BotEditor)
+    })
+  },
+  FinalsStatus: function () {
+    new Vue({
+      el: '#finals-status',
+      render: (h) => h(FinalsStatus, { props: { baseUrl: _global.baseUrl } })
     })
   },
   GameFeed: function () {

--- a/website/javascript/templates/FinalsStatus.vue
+++ b/website/javascript/templates/FinalsStatus.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="finals-status">
+    <h2 v-if="submissions_open">Submissions are still open, keep those improvements coming.</h2>
+    <h2 v-if="!finals_pairing">Matchmaking for the finals hasn't started yet.</h2>
+    <p v-if="finals_pairing">The current
+      <span v-if="!games_to_next">and last</span>
+      cutoff is at rank {{current_cutoff}}.
+      <span v-if="games_to_next">
+        The next cutoff begins in {{games_to_next}} games.
+      </span>
+    </p>
+    <p v-if="last_open_game">
+      {{finals_games}} games have been played in the finals.
+    </p>
+
+    <div v-if="cutoff_schedule">
+      <h2>Cutoff Schedule</h2>
+      <table class="table table-leader">
+        <thead>
+          <tr>
+            <th>Begins after</th>
+            <th v-if="last_open_game">At game</th>
+            <th>Cutoff rank</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for='cutoff in cutoff_schedule' v-bind:class="{'active_cutoff': finals_pairing && cutoff[1] == current_cutoff}">
+            <td>{{cutoff[0]}}</td>
+            <td v-if="last_open_game">{{last_open_game + cutoff[0]}}</td>
+            <td>{{cutoff[1]}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>The most recent game is
+        <a :href="'/play?game_id=' + current_game">
+          {{current_game}}
+        </a>
+        <span v-if="last_open_game">and the final game of open competition was
+          <a :href="'/play?game_id=' + last_open_game">
+            {{last_open_game}}
+          </a>
+        </span>.
+    </p>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import * as api from '../api'
+
+export default {
+  name: 'FinalsStatus',
+  props: ['baseUrl'],
+  data: function () {
+    return {
+      submissions_open: null,
+      finals_pairing: null,
+      current_game: null,
+      last_open_game: null,
+      cutoff_schedule: null,
+      finals_games: null,
+      current_cutoff: null,
+      games_to_next: null,
+    }
+  },
+  mounted: function () {
+    this.fetch()
+  },
+  methods: {
+    fetch: function () {
+      const url = `${api.API_SERVER_URL}/finals`
+      return new Promise((resolve, reject) => {
+        $.get(url).then((data) => {
+          console.log(data)
+          this.submissions_open = data.submissions_open
+          this.finals_pairing = data.finals_pairing
+          this.current_game = data.current_game
+          this.last_open_game = data.last_open_game
+          this.cutoff_schedule = data.cutoff_schedule
+          if (this.last_open_game) {
+            this.finals_games = this.current_game - this.last_open_game
+          } else {
+            this.finals_games = 0
+          }
+          if (this.finals_games > 0) {
+            for (const cutoff of this.cutoff_schedule) {
+              if (cutoff[0] > this.finals_games) { 
+                this.games_to_next = cutoff[0] - this.finals_games
+                break
+              }
+              this.current_cutoff = cutoff[1]
+            }
+          } else {
+            this.current_cutoff = this.cutoff_schedule[0][1]
+            this.games_to_next = this.cutoff_schedule[1][0]
+          }
+
+          resolve(data)
+        })
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+    .active_cutoff td {
+      background-color: #403b59;
+    }
+</style>


### PR DESCRIPTION
This adds a page to give information on the current state of finals and the cutoff schedule. While I think this includes the information needed, I'm sure it can still use some work on the verbiage and looks.

Here's some screenshots showing the current look for various states of the finals:
First while the open competition is still in progress:
![finals-status-open-competition](https://user-images.githubusercontent.com/392930/34676193-06e82e5a-f45a-11e7-9f86-4c18fea18644.png)
Once submissions close but before finals are started:
![finals-status-closed-competition](https://user-images.githubusercontent.com/392930/34676218-1c3dadfc-f45a-11e7-977d-5e745f817d28.png)
Shortly after finals have started:
![finals-status-start-finals](https://user-images.githubusercontent.com/392930/34676282-5213c7d6-f45a-11e7-80b0-14cfa58c5e6a.png)
After finals have progressed a few stages:
![finals-status-mid-stage](https://user-images.githubusercontent.com/392930/34676301-5b30c3dc-f45a-11e7-9db4-8b6eb6ba769e.png)
And the end stage:
![finals-status-end-stage](https://user-images.githubusercontent.com/392930/34676307-62db7afa-f45a-11e7-9846-7abf8278641a.png)
