### PR TITLE
Increase limit and ensure most recent challenges are shown.

### DIFF
--- a/website/javascript/templates/UserProfile.vue
+++ b/website/javascript/templates/UserProfile.vue
@@ -740,7 +740,7 @@
         },
         fetchChallengeGames: function(){
           this.challengeGames = []
-          let url = `${api.API_SERVER_URL}/user/${this.user.user_id}/challenge`
+          let url = `${api.API_SERVER_URL}/user/${this.user.user_id}/challenge?limit=200&order_by=desc,created`
           return $.get(url).then((data) => {
             let challenges = data.map((challenge) => {
               let newChallenge = challenge;


### PR DESCRIPTION
This increases the limit for number challenges displayed from 50 to 200. That should be enough to show the maximum number of challenges between two players in a month. Also specify the order of challenges received to ensure the most recent challenges are shown.