### PR TITLE
Update finals status page design.

### DIFF
--- a/website/javascript/templates/FinalsStatus.vue
+++ b/website/javascript/templates/FinalsStatus.vue
@@ -1,48 +1,107 @@
 <template>
   <div class="finals-status">
-    <h2 v-if="submissions_open">Submissions are still open, keep those improvements coming.</h2>
-    <h2 v-if="!finals_pairing">Matchmaking for the finals hasn't started yet.</h2>
-    <p v-if="finals_pairing">The current
-      <span v-if="!games_to_next">and last</span>
-      cutoff is at rank {{current_cutoff}}.
-      <span v-if="games_to_next">
-        The next cutoff begins in {{games_to_next}} games.
-      </span>
-    </p>
-    <p v-if="last_open_game">
-      {{finals_games}} games have been played in the finals.
-    </p>
+    <div v-if="submissions_open" style="text-align: center; padding: 1em;">
+        <p>Finals will start on January 22nd at 11:59:59PM EST.<br>
+          You can see a countdown clock <a href="https://www.timeanddate.com/countdown/generic?iso=20180122T235959&p0=179">here</a>.
+        </p>
+        <p>We will then take some time to reset all bots, during which no matches will be made.
+        </p>
+        <p>Once all is ready, we will reinstitute matchmaking for all bots in the competition,<br>
+          and then systematically remove the lowest ranking bots in groups until only the top {{cutoff_schedule[0].end_rank}} are left.<br>
+          The top {{cutoff_schedule[0].end_rank}} bots will play for the most games to determine high quality ratings and will play to the end.
+        </p>
+    </div>
+    <div v-else style="text-align: center; padding: 1em;">
+        <p>Finals began on January 22nd, 11:59:59PM EST.</p>
+        <template v-if="!finals_pairing">
+          <p> We are resetting all bots' rankings to zero, during which time no matches will be made.
+          </p>
+          <p>Once all is ready, we will reinstitute matchmaking for all bots in the competition,<br>
+            and then systematically remove the lowest ranking bots in groups until only the top {{cutoff_schedule[0].end_rank}} are left.<br>
+            The top {{cutoff_schedule[0].end_rank}} bots will play for the most games to determine high quality ratings and will play to the end.
+          </p>
+        </template>
+        <template v-else>
+          <p>Currently, bots are playing games and we are systematically removing the lowest ranking bots in groups until only the top {{cutoff_schedule[0].end_rank}} are left.<br>
+            The top {{cutoff_schedule[0].end_rank}} bots will play for the most games to determine high quality ratings and will play to the end.
+          </p>
+        </template>
+    </div>
+    <!-- When finals are complete replace the above divs with this one
+    <div style="text-align: center; padding: 1em;">
+      <p>Finals have ended! Check out the <a href="/programming-competition-leaderboard">leaderboard</a> to see who won.
+      </p>
+    </div>
+    -->
+    <table style="width:100%; table-layout:fixed; padding:1em;">
+        <tbody>
+            <tr>
+                <td style="width:50%; text-align:center;">
+                    <h2>CURRENT COMPETITION STATUS</h2>
+                    <p><strong>Submissions:</strong>
+                      <template v-if="submissions_open">
+                        OPEN
+                      </template>
+                      <template v-else>
+                        CLOSED
+                      </template>
+                    </p>
+                    <p><strong>Matchmaking:</strong>
+                      <template v-if="!finals_pairing">
+                        NOT YET STARTED
+                      </template>
+                      <template v-else>
+                        IN PROGRESS, {{finals_games}} PLAYED
+                      </template>
+                    </p>
+                    <p><strong>Ranks Currently Playing:</strong>
+                      1-{{current_cutoff}}
+                    </p>
+                </td>
+                <td style="width:50%; text-align:center;">
+                    <h2>GAME PROGRESS</h2>
+                    <p>The most recent game played is <a :href="'/play?game_id=' + current_game">{{current_game}}.</a></p>
+                    <p v-if="next_cutoff">Ranks {{next_cutoff+1}}-{{current_cutoff}} will be eliminated
+                      <template v-if="finals_pairing">in</template>
+                      <template v-else>after</template>
+                      {{games_to_next}} games.
+                    </p>
+                    <p v-else>Ranks 1-{{current_cutoff}} will continue playing to the end of the finals.</p>
+                    <p>The end of finals will be on January 29th, 9:00:00AM EST.</p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
     <div v-if="cutoff_schedule">
       <h2>Cutoff Schedule</h2>
       <table class="table table-leader">
         <thead>
           <tr>
-            <th>Begins after</th>
-            <th v-if="last_open_game">At game</th>
-            <th>Cutoff rank</th>
+            <th>Is Playing Currently?</th>
+            <th>Rank Range</th>
+            <th>Number of Games Before Cutoff</th>
+            <th v-if="last_open_game">Last Eligible Game ID</th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for='cutoff in cutoff_schedule' v-bind:class="{'active_cutoff': finals_pairing && cutoff[1] == current_cutoff}">
-            <td>{{cutoff[0]}}</td>
-            <td v-if="last_open_game">{{last_open_game + cutoff[0]}}</td>
-            <td>{{cutoff[1]}}</td>
+          <tr v-for='cutoff in cutoff_schedule' v-bind:class="{'hl': finals_pairing && cutoff.end_rank == current_cutoff}">
+            <td>
+              <template v-if="cutoff.end_rank <= current_cutoff">Yes</template>
+              <template v-else>No</template>
+            </td>
+            <td>{{cutoff.start_rank}}-{{cutoff.end_rank}}</td>
+            <td>{{cutoff.end_game || "Plays to end"}}</td>
+            <td v-if="last_open_game">
+              <template v-if="cutoff.end_game">
+                {{last_open_game + cutoff.end_game}}
+              </template>
+            </td>
           </tr>
         </tbody>
       </table>
+      <p>* Note that the highlighted group is the next group to be removed from the competition</p>
     </div>
-
-    <p>The most recent game is
-        <a :href="'/play?game_id=' + current_game">
-          {{current_game}}
-        </a>
-        <span v-if="last_open_game">and the final game of open competition was
-          <a :href="'/play?game_id=' + last_open_game">
-            {{last_open_game}}
-          </a>
-        </span>.
-    </p>
   </div>
 </template>
 
@@ -78,24 +137,41 @@ export default {
           this.finals_pairing = data.finals_pairing
           this.current_game = data.current_game
           this.last_open_game = data.last_open_game
-          this.cutoff_schedule = data.cutoff_schedule
           if (this.last_open_game) {
             this.finals_games = this.current_game - this.last_open_game
           } else {
             this.finals_games = 0
           }
+          this.cutoff_schedule = Array()
+          for (let i=0; i < data.cutoff_schedule.length; i++) {
+            let cutoff = {}
+            if (i < data.cutoff_schedule.length - 1) {
+              cutoff.start_rank = data.cutoff_schedule[i+1][1] + 1
+              cutoff.end_game = data.cutoff_schedule[i+1][0]
+            } else {
+              cutoff.start_rank = 1;
+              cutoff.end_game = null;
+            }
+            cutoff.start_game = data.cutoff_schedule[i][0]
+            cutoff.end_rank = data.cutoff_schedule[i][1]
+            this.cutoff_schedule.push(cutoff)
+          }
           if (this.finals_games > 0) {
             for (const cutoff of this.cutoff_schedule) {
-              if (cutoff[0] > this.finals_games) { 
-                this.games_to_next = cutoff[0] - this.finals_games
+              if (cutoff.start_game > this.finals_games) {
+                this.next_cutoff = cutoff.end_rank
+                this.next_start = cutoff.start_game
+                this.games_to_next = cutoff.start_game - this.finals_games
                 break
               }
-              this.current_cutoff = cutoff[1]
+              this.current_cutoff = cutoff.end_rank
             }
           } else {
-            this.current_cutoff = this.cutoff_schedule[0][1]
-            this.games_to_next = this.cutoff_schedule[1][0]
+            this.current_cutoff = this.cutoff_schedule[0].end_rank
+            this.next_cutoff = this.cutoff_schedule[1].end_rank
+            this.games_to_next = this.cutoff_schedule[1].start_game
           }
+          this.cutoff_schedule.reverse()
 
           resolve(data)
         })
@@ -104,9 +180,3 @@ export default {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-    .active_cutoff td {
-      background-color: #403b59;
-    }
-</style>

--- a/website/javascript/templates/FinalsStatus.vue
+++ b/website/javascript/templates/FinalsStatus.vue
@@ -100,7 +100,7 @@
           </tr>
         </tbody>
       </table>
-      <p>* Note that the highlighted group is the next group to be removed from the competition</p>
+      <p v-if="finals_pairing">* Note that the highlighted group is the next group to be removed from the competition</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Updated page design from @julskast 

@julskast I did make a few more tweeks from the last one I showed you, so you'll probably want to look it over. I think the largest was adding the current number of games played in the finals to the matchmaking status.

During open competition:
![open-competition](https://user-images.githubusercontent.com/392930/35105379-8a7c0c50-fc39-11e7-9c68-93e6a2ff4a8d.png)

After submissions close, before finals start:
![closed-submissions](https://user-images.githubusercontent.com/392930/35105413-99b7ffe4-fc39-11e7-8163-da81f324536a.png)

Shortly after the games have started:
![start](https://user-images.githubusercontent.com/392930/35105432-a6a85f14-fc39-11e7-9421-dbd5c3ba65f3.png)

Middle stage:
![mid](https://user-images.githubusercontent.com/392930/35105442-afb28cf6-fc39-11e7-89a9-4da07583182a.png)

End stage:
![end-stage](https://user-images.githubusercontent.com/392930/35105449-b50dd502-fc39-11e7-82a4-c23c79efb0a4.png)
