### PR TITLE
Fix HaliteTV Pause/Play buttons

### DIFF
--- a/website/javascript/templates/HaliteTV.vue
+++ b/website/javascript/templates/HaliteTV.vue
@@ -57,12 +57,13 @@
                 <span class="replay-btn">
                   <a href="javascript:;" @click="prevFrame"><span class="icon-prev"></span></a>
                 </span>
-                <span v-if="playing" class="replay-btn" style="text-align: center">
+                <span v-if="!playing" class="replay-btn" style="text-align: center">
                   <a href="javascript:;" @click="playVideo"><span class="icon-play"></span></a>
                 </span>
-                <span v-if="!playing" class="replay-btn" style="text-align: center">
+                <span v-if="playing" class="replay-btn" style="text-align: center">
                   <a href="javascript:;" @click="pauseVideo"><span class="icon-pause"></span></a>
                 </span>
+                
                 <span class="replay-btn">
                   <a href="javascript:;" @click="nextFrame"><span class="icon-next"></span></a>
                 </span>


### PR DESCRIPTION
Solution to [this issue](https://github.com/HaliteChallenge/Halite-II/issues/459).

HaliteTV pause and play buttons are flipped. And the source code of the buttons is different from [the source code of the /play page](https://github.com/HaliteChallenge/Halite-II/blob/e9a8fd02cc86abfa693d2488f8fcc62bd2ca0467/website/javascript/templates/Visualizer.vue#L53).