### PR TITLE
Fix spelling of logging dirname key namespace.

### DIFF
--- a/airesources/Clojure/src/hlt/log.clj
+++ b/airesources/Clojure/src/hlt/log.clj
@@ -21,7 +21,7 @@
 
 (defn log-game-map
   [turn game-map]
-  (let [{:keys [com.grzm.halite2.log/dirname bot-name]} @config
+  (let [{:keys [hlt.log/dirname bot-name]} @config
         game-map-file (format "%s/%s-game-map-%03d.edn" dirname bot-name turn)]
     (spit game-map-file game-map)))
 


### PR DESCRIPTION
Noticed this when I saw the pull request was merged. This was a leftover from my local development build.